### PR TITLE
fix: free intermediate arrays before second lh5.read in nopt

### DIFF
--- a/src/legenddataflowscripts/par/geds/dsp/nopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/nopt.py
@@ -114,10 +114,12 @@ def par_geds_dsp_nopt() -> None:
         dsp_data = build_dsp(raw_in=tb_data, dsp_config=dsp_config)
         cut_dict = generate_cuts(dsp_data, cut_dict=opt_dict.pop("cut_pars"))
         cut_idxs = get_cut_indexes(dsp_data, cut_dict)
+        n_events = opt_dict.pop("n_events")
+        del tb_data, dsp_data
         tb_data = lh5.read(
             args.raw_table_name,
             raw_files,
-            n_rows=opt_dict.pop("n_events"),
+            n_rows=n_events,
             idx=idxs[cut_idxs],
         )
         msg = f"... {len(tb_data)} baselines after cuts"
@@ -134,7 +136,7 @@ def par_geds_dsp_nopt() -> None:
             )
         else:
             out_dict = pno.noise_optimization(
-                raw_files, dsp_config, db_dict.copy(), opt_dict, args.raw_table_name
+                tb_data, dsp_config, db_dict.copy(), opt_dict, args.raw_table_name
             )
 
         t2 = time.time()


### PR DESCRIPTION
## Summary

- Explicitly `del tb_data, dsp_data` before the second `lh5.read` call in `par_geds_dsp_nopt` so the first read's memory is released before the second allocation, reducing peak RSS by ~2×
- Fix no-plot branch passing `raw_files` instead of `tb_data` to `noise_optimization`
- Extract `n_events = opt_dict.pop("n_events")` before the `del` so the value is available for the second read

## Test plan

- [ ] Run `par-geds-dsp-nopt` on a test channel and verify it completes without memory errors
- [ ] Verify `--plot-path` and no-plot-path branches both produce correct output