### PR TITLE
Bump dependencies and migrate to legend-lh5io

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,7 @@ intersphinx_mapping = {
     "dspeed": ("https://dspeed.readthedocs.io/en/stable", None),
     "daq2lh5": ("https://legend-daq2lh5.readthedocs.io/en/stable", None),
     "lgdo": ("https://legend-pydataobj.readthedocs.io/en/stable", None),
+    "lh5": ("https://legend-lh5io.readthedocs.io/en/stable", None),
     "dbetto": ("https://dbetto.readthedocs.io/en/stable", None),
     "pylegendmeta": ("https://pylegendmeta.readthedocs.io/en/stable", None),
 }  # add new intersphinx mappings here

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -156,8 +156,10 @@ Key Dependencies
    * - `pygama <https://pygama.readthedocs.io>`_
      - Calibration algorithms (energy cal, A/E, LQ, noise optimisation, etc.)
        and the HIT tier builder.
-   * - `lgdo / lh5 <https://legend-pydataobj.readthedocs.io>`_
-     - LEGEND Data Object format and LH5 file I/O.
+   * - `lgdo <https://legend-pydataobj.readthedocs.io>`_
+     - LEGEND Data Object types.
+   * - `lh5 <https://legend-lh5io.readthedocs.io>`_
+     - LH5 file I/O.
    * - `dbetto <https://dbetto.readthedocs.io>`_
      - Configuration file handling (JSON/YAML, TextDB, validity catalogs).
    * - `pylegendmeta <https://pylegendmeta.readthedocs.io>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "dspeed>=2.1.4",
     "pylegendmeta>=1.4.4",
     "legend-pydataobj>=2.0.2",
+    "legend-lh5io>=0.2.6",
     "pip",
 ]
 # "legend-daq2lh5 @  file:///${PROJECT_ROOT}/software/python/src/legend-daq2lh5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,11 @@ dynamic = ["version"]
 
 dependencies = [
     "colorlog",
-    "dbetto>=1.2.3",
-    "pygama>=2.3.8",
-    "dspeed>=2.0",
-    "pylegendmeta>=1.2.5",
-    "legend-pydataobj>=1.16",
+    "dbetto>=1.3.6",
+    "pygama>=2.3.10",
+    "dspeed>=2.1.4",
+    "pylegendmeta>=1.4.4",
+    "legend-pydataobj>=2.0.2",
     "pip",
 ]
 # "legend-daq2lh5 @  file:///${PROJECT_ROOT}/software/python/src/legend-daq2lh5

--- a/src/legenddataflowscripts/par/geds/dsp/dplms.py
+++ b/src/legenddataflowscripts/par/geds/dsp/dplms.py
@@ -5,10 +5,11 @@ import pickle as pkl
 import time
 from pathlib import Path
 
+import lh5
 import numpy as np
 import pygama.math.distributions as pmd  # noqa: F401
 from dbetto.catalog import Props
-from lgdo import Array, Table, lh5
+from lgdo import Array, Table
 from pygama.pargen.data_cleaning import generate_cuts
 from pygama.pargen.dplms_ge_dict import dplms_ge_dict
 from pygama.pargen.dsp_optimize import run_one_dsp

--- a/src/legenddataflowscripts/par/geds/dsp/eopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/eopt.py
@@ -371,7 +371,7 @@ def par_geds_dsp_eopt() -> None:
             n_iter=opt_dict["n_iter"],
         )
 
-        Props.add_to(db_dict, out_param_dict)
+        db_dict = Props.add_to(db_dict, out_param_dict)
 
         # db_dict.update(out_param_dict)
 

--- a/src/legenddataflowscripts/par/geds/dsp/eopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/eopt.py
@@ -6,13 +6,13 @@ import time
 import warnings
 from pathlib import Path
 
+import lh5
 import numpy as np
 import pygama.pargen.energy_optimisation as om  # noqa: F401
 import sklearn.gaussian_process.kernels as ker
 from dbetto.catalog import Props
 from dspeed import build_dsp
 from dspeed.units import unit_registry as ureg
-from lgdo import lh5
 from pygama.math.distributions import hpge_peak
 from pygama.pargen.dsp_optimize import (
     BayesianOptimizer,

--- a/src/legenddataflowscripts/par/geds/dsp/evtsel.py
+++ b/src/legenddataflowscripts/par/geds/dsp/evtsel.py
@@ -9,12 +9,12 @@ from bisect import bisect_left
 from pathlib import Path
 
 import lgdo
+import lh5
 import numpy as np
 import pygama.math.histogram as pgh
 import pygama.pargen.energy_cal as pgc
 from dbetto.catalog import Props
 from dspeed import build_dsp
-from lgdo import lh5
 from pygama.pargen.data_cleaning import generate_cuts, get_keys
 
 from ....utils import build_log, get_pulser_mask

--- a/src/legenddataflowscripts/par/geds/dsp/nopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/nopt.py
@@ -5,11 +5,11 @@ import pickle as pkl
 import time
 from pathlib import Path
 
+import lh5
 import numpy as np
 import pygama.pargen.noise_optimization as pno
 from dbetto.catalog import Props
 from dspeed import build_dsp
-from lgdo import lh5
 from pygama.pargen.data_cleaning import generate_cuts, get_cut_indexes
 
 from ....utils import build_log

--- a/src/legenddataflowscripts/par/geds/dsp/pz.py
+++ b/src/legenddataflowscripts/par/geds/dsp/pz.py
@@ -5,10 +5,10 @@ import copy
 import pickle as pkl
 from pathlib import Path
 
+import lh5
 import numpy as np
 from dbetto.catalog import Props
 from dspeed import build_dsp
-from lgdo import lh5
 from pygama.pargen.data_cleaning import get_cut_indexes
 from pygama.pargen.pz_correct import PZCorrect
 

--- a/src/legenddataflowscripts/par/geds/dsp/svm_build.py
+++ b/src/legenddataflowscripts/par/geds/dsp/svm_build.py
@@ -4,8 +4,8 @@ import argparse
 import pickle as pkl
 from pathlib import Path
 
+import lh5
 from dbetto.catalog import Props
-from lgdo import lh5
 from sklearn.svm import SVC
 
 from ....utils import build_log

--- a/src/legenddataflowscripts/par/geds/hit/ecal.py
+++ b/src/legenddataflowscripts/par/geds/hit/ecal.py
@@ -7,13 +7,13 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 
+import lh5
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pygama.math.distributions as pgf
 import pygama.math.histogram as pgh
 from dbetto.catalog import Props
-from lgdo import lh5
 from matplotlib.colors import LogNorm
 from pygama.math.distributions import nb_poly
 from pygama.pargen.data_cleaning import get_mode_stdev

--- a/src/legenddataflowscripts/par/geds/hit/qc.py
+++ b/src/legenddataflowscripts/par/geds/hit/qc.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import numpy as np
 from dbetto.catalog import Props
-from lgdo.lh5 import ls
+from lh5 import ls
 from pygama.pargen.data_cleaning import (
     generate_cut_classifiers,
     get_keys,

--- a/src/legenddataflowscripts/tier/dsp.py
+++ b/src/legenddataflowscripts/tier/dsp.py
@@ -7,11 +7,11 @@ import warnings
 from multiprocessing import Pool
 from pathlib import Path
 
+import lh5
 import numpy as np
 from dbetto import TextDB
 from dbetto.catalog import Props
 from dspeed import build_dsp
-from lgdo import lh5
 
 from ..utils import alias_table, build_log
 

--- a/src/legenddataflowscripts/tier/hit.py
+++ b/src/legenddataflowscripts/tier/hit.py
@@ -6,8 +6,8 @@ import time
 from pathlib import Path
 
 import lh5
+from dbetto import TextDB
 from dbetto.catalog import Props
-from legendmeta import TextDB
 from pygama.hit.build_hit import build_hit
 
 from ..utils import alias_table, build_log
@@ -96,7 +96,7 @@ def build_tier_hit() -> None:
         hit_cfg = Props.read_from(file)
 
         # get pars (to override hit config)
-        Props.add_to(hit_cfg, pars_dict.get(chan, {}).copy())
+        hit_cfg = Props.add_to(hit_cfg, pars_dict.get(chan, {}).copy())
 
         if chan in table_map:
             input_tbl_name = table_map[chan] if table_map is not None else chan + "/dsp"
@@ -203,7 +203,7 @@ def build_tier_hit_single_channel() -> None:
     )
 
     hit_cfg = Props.read_from(chan_cfg_map)
-    Props.add_to(hit_cfg, pars_dict.copy())
+    hit_cfg = Props.add_to(hit_cfg, pars_dict.copy())
 
     log.info("running build_hit()...")
     start = time.time()

--- a/src/legenddataflowscripts/tier/hit.py
+++ b/src/legenddataflowscripts/tier/hit.py
@@ -5,9 +5,9 @@ import json
 import time
 from pathlib import Path
 
+import lh5
 from dbetto.catalog import Props
 from legendmeta import TextDB
-from lgdo import lh5
 from pygama.hit.build_hit import build_hit
 
 from ..utils import alias_table, build_log

--- a/src/legenddataflowscripts/workflow/filedb.py
+++ b/src/legenddataflowscripts/workflow/filedb.py
@@ -4,9 +4,9 @@ import argparse
 import logging
 from pathlib import Path
 
+import lh5
 import numpy as np
 from dbetto.catalog import Props
-from lgdo import lh5
 from pygama.flow.file_db import FileDB
 
 


### PR DESCRIPTION
## Summary

- Bump all major dependencies to latest PyPI releases: `dbetto` 1.3.6, `pygama` 2.3.10, `dspeed` 2.1.4, `pylegendmeta` 1.4.4, `legend-pydataobj` 2.0.2
- Add `legend-lh5io>=0.2.6` — `legend-pydataobj>=2.0` moved LH5 file I/O to this dedicated package; migrate all `from lgdo import lh5` / `from lgdo.lh5 import X` imports across 10 source files
- Fix two breaking API changes introduced in `dbetto` 1.3.5:
  - `legendmeta.TextDB` removed — now imported from `dbetto` directly
  - `Props.add_to()` no longer mutates in place but returns a new dict — capture the return value at all three call sites (`hit.py` ×2, `eopt.py` ×1)
- Update Sphinx intersphinx config and overview docs to reference the new `legend-lh5io` docs

## Test plan

- [x] `pytest` — all 7 tests pass