### PR TITLE
Sanity-check all script inputs up front

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dynamic = ["version"]
 
 dependencies = [
     "colorlog",
-    "dbetto>=1.3.6",
+    "dbetto>=1.4",
     "pygama>=2.3.10",
     "dspeed>=2.1.4",
     "pylegendmeta>=1.4.4",

--- a/src/legenddataflowscripts/par/geds/dsp/dplms.py
+++ b/src/legenddataflowscripts/par/geds/dsp/dplms.py
@@ -14,7 +14,14 @@ from pygama.pargen.data_cleaning import generate_cuts
 from pygama.pargen.dplms_ge_dict import dplms_ge_dict
 from pygama.pargen.dsp_optimize import run_one_dsp
 
-from ....utils import build_log, convert_dict_np_to_float, require_config_keys
+from ....utils import (
+    build_log,
+    check_input_files,
+    convert_dict_np_to_float,
+    expand_filelist,
+    prepare_output_paths,
+    require_config_keys,
+)
 
 
 def par_geds_dsp_dplms() -> None:
@@ -100,8 +107,13 @@ def par_geds_dsp_dplms() -> None:
 
     args = argparser.parse_args()
 
-    dsp_config = Props.read_from(args.processing_chain)
     log = build_log(args.log_config, args.log)
+
+    check_input_files(args.peak_file, "--peak-file")
+    check_input_files(args.inplots, "--inplots")
+    prepare_output_paths(args.lh5_path, args.dsp_pars, args.plot_path)
+
+    dsp_config = Props.read_from(args.processing_chain)
 
     t0 = time.time()
 
@@ -110,8 +122,7 @@ def par_geds_dsp_dplms() -> None:
     require_config_keys(dplms_dict, ["run_dplms"], f"dplms config ({args.config_file})")
 
     if dplms_dict["run_dplms"] is True:
-        with Path(args.fft_raw_filelist).open() as f:
-            fft_files = sorted(f.read().splitlines())
+        fft_files = expand_filelist([args.fft_raw_filelist], "--fft-raw-filelist")
 
         t0 = time.time()
         log.info("\nLoad fft data")
@@ -202,17 +213,14 @@ def par_geds_dsp_dplms() -> None:
 
     db_dict.update(out_dict)
 
-    Path(args.lh5_path).parent.mkdir(parents=True, exist_ok=True)
     lh5.write(
         Table(col_dict={"dplms": dplms_pars}),
         name=args.channel,
         lh5_file=args.lh5_path,
         wo_mode="overwrite",
     )
-    Path(args.dsp_pars).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.dsp_pars, convert_dict_np_to_float(db_dict))
 
     if args.plot_path:
-        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_path).open("wb") as f:
             pkl.dump(inplot_dict, f, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/par/geds/dsp/eopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/eopt.py
@@ -19,7 +19,12 @@ from pygama.pargen.dsp_optimize import (
     run_bayesian_optimisation,
 )
 
-from ....utils import build_log, require_config_keys
+from ....utils import (
+    build_log,
+    check_input_files,
+    prepare_output_paths,
+    require_config_keys,
+)
 
 warnings.filterwarnings(action="ignore", category=RuntimeWarning)
 try:
@@ -117,8 +122,13 @@ def par_geds_dsp_eopt() -> None:
     )
     args = argparser.parse_args()
 
-    dsp_config = Props.read_from(args.processing_chain)
     log = build_log(args.log_config, args.log)
+
+    check_input_files(args.peak_file, "--peak-file")
+    check_input_files(args.inplots, "--inplots")
+    prepare_output_paths(args.qbb_grid_path, args.final_dsp_pars, args.plot_path)
+
+    dsp_config = Props.read_from(args.processing_chain)
 
     t0 = time.time()
 
@@ -418,14 +428,12 @@ def par_geds_dsp_eopt() -> None:
         else:
             db_dict.update({"ctc_params": out_alpha_dict})
 
-        Path(args.qbb_grid_path).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.qbb_grid_path).open("wb") as f:
             pkl.dump({"eopt": optimisers}, f, protocol=pkl.HIGHEST_PROTOCOL)
 
     else:
         Path(args.qbb_grid_path).touch()
 
-    Path(args.final_dsp_pars).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.final_dsp_pars, db_dict)
 
     if args.plot_path:
@@ -452,6 +460,5 @@ def par_geds_dsp_eopt() -> None:
                 "acq_space": bopt_zac.plot_acq(init_samples=sample_x),
             }
 
-        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_path).open("wb") as w:
             pkl.dump(plot_dict, w, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/par/geds/dsp/evtsel.py
+++ b/src/legenddataflowscripts/par/geds/dsp/evtsel.py
@@ -21,6 +21,7 @@ from ....utils import (
     build_log,
     check_pulser_mask,
     expand_filelist,
+    get_channel_config,
     get_pulser_mask,
     require_config_keys,
 )
@@ -292,9 +293,11 @@ def par_geds_dsp_evtsel() -> None:
             )
 
         if args.raw_cal_curve:
-            raw_dict = Props.read_from(args.raw_cal_curve)[args.channel]["pars"][
-                "operations"
-            ]
+            raw_dict = get_channel_config(
+                Props.read_from(args.raw_cal_curve),
+                args.channel,
+                name="--raw-cal-curve",
+            )["pars"]["operations"]
         else:
             E_uncal = tb[energy_field].nda
             E_uncal = E_uncal[E_uncal > 200]

--- a/src/legenddataflowscripts/par/geds/dsp/nopt.py
+++ b/src/legenddataflowscripts/par/geds/dsp/nopt.py
@@ -12,7 +12,13 @@ from dbetto.catalog import Props
 from dspeed import build_dsp
 from pygama.pargen.data_cleaning import generate_cuts, get_cut_indexes
 
-from ....utils import build_log, require_config_keys
+from ....utils import (
+    build_log,
+    check_input_files,
+    expand_filelist,
+    prepare_output_paths,
+    require_config_keys,
+)
 
 
 def par_geds_dsp_nopt() -> None:
@@ -84,8 +90,12 @@ def par_geds_dsp_nopt() -> None:
 
     args = argparser.parse_args()
 
-    dsp_config = Props.read_from(args.processing_chain)
     log = build_log(args.log_config, args.log)
+
+    check_input_files(args.inplots, "--inplots")
+    prepare_output_paths(args.dsp_pars, args.plot_path)
+
+    dsp_config = Props.read_from(args.processing_chain)
 
     t0 = time.time()
 
@@ -94,10 +104,7 @@ def par_geds_dsp_nopt() -> None:
     require_config_keys(opt_dict, ["run_nopt"], f"nopt config ({args.config_file})")
 
     if opt_dict.pop("run_nopt") is True:
-        with Path(args.raw_filelist).open() as f:
-            files = f.read().splitlines()
-
-        raw_files = sorted(files)
+        raw_files = expand_filelist([args.raw_filelist], "--raw-filelist")
 
         energies = lh5.read_as(
             f"{args.raw_table_name}/daqenergy", raw_files, library="np"
@@ -152,7 +159,6 @@ def par_geds_dsp_nopt() -> None:
         plot_dict = {}
 
     if args.plot_path:
-        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
         if args.inplots:
             with Path(args.inplots).open("rb") as r:
                 old_plot_dict = pkl.load(r)
@@ -162,5 +168,4 @@ def par_geds_dsp_nopt() -> None:
         with Path(args.plot_path).open("wb") as f:
             pkl.dump(plot_dict, f, protocol=pkl.HIGHEST_PROTOCOL)
 
-    Path(args.dsp_pars).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.dsp_pars, {**db_dict, "nopt_pars": out_dict})

--- a/src/legenddataflowscripts/par/geds/dsp/pz.py
+++ b/src/legenddataflowscripts/par/geds/dsp/pz.py
@@ -18,6 +18,7 @@ from ....utils import (
     convert_dict_np_to_float,
     expand_filelist,
     get_pulser_mask,
+    prepare_output_paths,
     require_config_keys,
 )
 
@@ -101,6 +102,9 @@ def par_geds_dsp_pz() -> None:
     args = argparser.parse_args()
 
     log = build_log(args.log_config, args.log)
+
+    prepare_output_paths(args.output_file, args.plot_path)
+
     kwarg_dict = Props.read_from(args.config_file)
     require_config_keys(kwarg_dict, ["run_tau"], f"pz config ({args.config_file})")
 
@@ -223,8 +227,6 @@ def par_geds_dsp_pz() -> None:
         tau.dsp_config = dsp_config_optimise_removed
 
         if args.plot_path:
-            Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
-
             plot_dict = tau.plot_waveforms_after_correction(
                 tb_data,
                 kwarg_dict.get("wf_pz_field", "wf_pz"),
@@ -259,5 +261,4 @@ def par_geds_dsp_pz() -> None:
     else:
         out_dict = {}
 
-    Path(args.output_file).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.output_file, out_dict)

--- a/src/legenddataflowscripts/par/geds/dsp/svm.py
+++ b/src/legenddataflowscripts/par/geds/dsp/svm.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from dbetto.catalog import Props
 
+from ....utils import check_input_files
+
 
 def par_geds_dsp_svm() -> None:
     """Register a pre-trained SVM model file in the DSP parameter database.
@@ -43,6 +45,9 @@ def par_geds_dsp_svm() -> None:
     )
     argparser.add_argument("--svm-file", help="svm file", required=True)
     args = argparser.parse_args()
+
+    # a bad --svm-file would otherwise be silently embedded into the pars
+    check_input_files(args.svm_file, "--svm-file")
 
     par_data = Props.read_from(args.input_file) if args.input_file else {}
 

--- a/src/legenddataflowscripts/par/geds/dsp/svm_build.py
+++ b/src/legenddataflowscripts/par/geds/dsp/svm_build.py
@@ -8,7 +8,7 @@ import lh5
 from dbetto.catalog import Props
 from sklearn.svm import SVC
 
-from ....utils import build_log
+from ....utils import build_log, check_input_files, prepare_output_paths
 
 
 def par_geds_dsp_svm_build() -> None:
@@ -62,7 +62,14 @@ def par_geds_dsp_svm_build() -> None:
 
     log = build_log(args.log_config, args.log)
 
+    prepare_output_paths(args.output_file)
+
     if args.train_data is not None and len(args.train_data) > 0:
+        if args.train_hyperpars is None:
+            msg = "--train-hyperpars is required when --train-data is given"
+            raise ValueError(msg)
+        check_input_files(args.train_data, "--train-data")
+
         # Load files
         tb = lh5.read("ml_train/dsp", args.train_data)
         log.debug("loaded data")

--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -22,6 +22,7 @@ from ....utils import (
     expand_filelist,
     fill_plot_dict,
     get_pulser_mask,
+    prepare_output_paths,
     require_config_keys,
 )
 
@@ -340,6 +341,9 @@ def par_geds_hit_aoe() -> None:
     args = argparser.parse_args()
 
     log = build_log(args.log_config, args.log)
+
+    prepare_output_paths(args.plot_file, args.hit_pars, args.aoe_results)
+
     kwarg_dict = Props.read_from(args.config_file)
     require_config_keys(kwarg_dict, ["run_aoe"], f"aoe config ({args.config_file})")
 
@@ -411,6 +415,9 @@ def par_geds_hit_aoe() -> None:
 
         override_dict = None
         if args.override_files:
+            if args.detector is None:
+                msg = "--detector is required when --override-files is given"
+                raise ValueError(msg)
             override_dict = Props.read_from(args.override_files)
             override_dict = override_dict.get(args.detector, None)
 
@@ -433,11 +440,9 @@ def par_geds_hit_aoe() -> None:
         plot_dict = out_plot_dict
         results_dict = {}
     if args.plot_file:
-        Path(args.plot_file).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_file).open("wb") as w:
             pkl.dump(plot_dict, w, protocol=pkl.HIGHEST_PROTOCOL)
 
-    Path(args.hit_pars).parent.mkdir(parents=True, exist_ok=True)
     final_hit_dict = {
         "pars": {"operations": cal_dict},
         "results": results_dict,
@@ -447,6 +452,5 @@ def par_geds_hit_aoe() -> None:
 
     Props.write_to(args.hit_pars, final_hit_dict)
 
-    Path(args.aoe_results).parent.mkdir(parents=True, exist_ok=True)
     with Path(args.aoe_results).open("wb") as w:
         pkl.dump(dict(**object_dict, aoe=aoe), w, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/par/geds/hit/ecal.py
+++ b/src/legenddataflowscripts/par/geds/hit/ecal.py
@@ -824,7 +824,7 @@ def par_geds_hit_ecal() -> None:
 
     db_files = [
         par_file
-        for par_file in args.ctc_dict
+        for par_file in (args.ctc_dict or [])
         if Path(par_file).suffix in (".json", ".yml", ".yaml")
     ]
     if args.ctc_dict and not db_files:

--- a/src/legenddataflowscripts/par/geds/hit/ecal.py
+++ b/src/legenddataflowscripts/par/geds/hit/ecal.py
@@ -27,6 +27,7 @@ from ....utils import (
     convert_dict_np_to_float,
     expand_filelist,
     get_pulser_mask,
+    prepare_output_paths,
     require_config_keys,
 )
 
@@ -812,6 +813,8 @@ def par_geds_hit_ecal() -> None:
 
     log = build_log(args.log_config, args.log)
 
+    prepare_output_paths(args.plot_path, args.save_path, args.results_path)
+
     hit_dict = {}
     in_results_dict = {}
     if args.in_hit_dict:
@@ -824,12 +827,23 @@ def par_geds_hit_ecal() -> None:
         for par_file in args.ctc_dict
         if Path(par_file).suffix in (".json", ".yml", ".yaml")
     ]
+    if args.ctc_dict and not db_files:
+        msg = (
+            f"--ctc-dict: none of the provided files {args.ctc_dict} has a "
+            ".json/.yml/.yaml extension"
+        )
+        raise ValueError(msg)
 
     database_dic = Props.read_from(db_files)
 
     if args.channel and args.channel in database_dic:
         database_dic = database_dic[args.channel]
 
+    require_config_keys(
+        database_dic,
+        ["ctc_params"],
+        f"ctc dict for channel {args.channel} ({args.ctc_dict})",
+    )
     hit_dict.update(database_dic["ctc_params"])
 
     kwarg_dict = Props.read_from(args.config_file)
@@ -1146,7 +1160,6 @@ def par_geds_hit_ecal() -> None:
 
         total_plot_dict.update({"ecal": plot_dict})
 
-        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_path).open("wb") as f:
             pkl.dump(total_plot_dict, f, protocol=pkl.HIGHEST_PROTOCOL)
 
@@ -1158,5 +1171,4 @@ def par_geds_hit_ecal() -> None:
 
     # save calibration objects
     with Path(args.results_path).open("wb") as fp:
-        Path(args.results_path).parent.mkdir(parents=True, exist_ok=True)
         pkl.dump({"ecal": full_object_dict}, fp, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/par/geds/hit/lq.py
+++ b/src/legenddataflowscripts/par/geds/hit/lq.py
@@ -24,6 +24,7 @@ from ....utils import (
     expand_filelist,
     fill_plot_dict,
     get_pulser_mask,
+    prepare_output_paths,
     require_config_keys,
 )
 
@@ -371,6 +372,9 @@ def par_geds_hit_lq() -> None:
     args = argparser.parse_args()
 
     build_log(args.log_config, args.log)
+
+    prepare_output_paths(args.plot_file, args.hit_pars, args.lq_results)
+
     kwarg_dict = Props.read_from(args.config_file)
     require_config_keys(kwarg_dict, ["run_lq"], f"lq config ({args.config_file})")
 
@@ -450,7 +454,6 @@ def par_geds_hit_lq() -> None:
         results_dict = {}
 
     if args.plot_file:
-        Path(args.plot_file).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_file).open("wb") as w:
             pkl.dump(plot_dict, w, protocol=pkl.HIGHEST_PROTOCOL)
 
@@ -460,13 +463,11 @@ def par_geds_hit_lq() -> None:
             "results": results_dict,
         }
     )
-    Path(args.hit_pars).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.hit_pars, final_hit_dict)
 
     final_object_dict = dict(
         **object_dict,
         lq=lq,
     )
-    Path(args.lq_results).parent.mkdir(parents=True, exist_ok=True)
     with Path(args.lq_results).open("wb") as w:
         pkl.dump(final_object_dict, w, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/par/geds/hit/qc.py
+++ b/src/legenddataflowscripts/par/geds/hit/qc.py
@@ -24,6 +24,7 @@ from ....utils import (
     convert_dict_np_to_float,
     expand_filelist,
     get_pulser_mask,
+    prepare_output_paths,
 )
 
 log = logging.getLogger(__name__)
@@ -420,7 +421,9 @@ def par_geds_hit_qc() -> None:
     argparser.add_argument("--save-path", help="save_path", type=str)
     args = argparser.parse_args()
 
-    build_log(args.log_config, args.log)
+    log = build_log(args.log_config, args.log)
+
+    prepare_output_paths(args.save_path, args.plot_path)
 
     # get metadata dictionary
     kwarg_dict = Props.read_from(args.config_file)
@@ -458,10 +461,8 @@ def par_geds_hit_qc() -> None:
     msg = f"qc took {time.time() - start:.2f} seconds"
     log.info(msg)
 
-    Path(args.save_path).parent.mkdir(parents=True, exist_ok=True)
     Props.write_to(args.save_path, out_dict)
 
     if args.plot_path:
-        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
         with Path(args.plot_path).open("wb") as f:
             pkl.dump({"qc": plot_dict}, f, protocol=pkl.HIGHEST_PROTOCOL)

--- a/src/legenddataflowscripts/tier/dsp.py
+++ b/src/legenddataflowscripts/tier/dsp.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import time
 import warnings
 from multiprocessing import Pool
@@ -9,11 +8,17 @@ from pathlib import Path
 
 import lh5
 import numpy as np
-from dbetto import TextDB
 from dbetto.catalog import Props
 from dspeed import build_dsp
 
-from ..utils import alias_table, build_log
+from ..utils import (
+    alias_table,
+    build_log,
+    check_input_files,
+    get_rule_config,
+    parse_json_arg,
+    prepare_output_paths,
+)
 
 warnings.filterwarnings(action="ignore", category=RuntimeWarning)
 
@@ -130,13 +135,20 @@ def build_tier_dsp() -> None:
     # set number of threads to use
     # set_num_threads(1)
 
-    table_map = json.loads(args.table_map)
-
-    df_configs = TextDB(args.configs, lazy=True)
-    config_dict = df_configs.on(args.timestamp, system=args.datatype).snakemake_rules
-    config_dict = config_dict[f"tier_{args.tier}"]
+    config_dict = get_rule_config(
+        args.configs, f"tier_{args.tier}", args.timestamp, args.datatype
+    )
 
     log = build_log(config_dict, args.log, fallback=__name__)
+
+    table_map = parse_json_arg(args.table_map, "--table-map")
+    alias_map = (
+        parse_json_arg(args.alias_table, "--alias-table")
+        if args.alias_table is not None
+        else None
+    )
+    check_input_files(args.input, "--input")
+    prepare_output_paths(args.output)
 
     settings_dict = config_dict.options.get("settings", {})
     if isinstance(settings_dict, str):
@@ -175,6 +187,12 @@ def build_tier_dsp() -> None:
         for par_file in args.pars_file
         if Path(par_file).suffix in (".json", ".yaml", ".yml")
     ]
+    if args.pars_file and not db_files:
+        msg = (
+            f"--pars-file: none of the provided files {args.pars_file} has a "
+            ".json/.yaml/.yml extension"
+        )
+        raise ValueError(msg)
 
     database_dict = _replace_list_with_array(
         Props.read_from(db_files, subst_pathvar=True)
@@ -184,8 +202,6 @@ def build_tier_dsp() -> None:
         for chan, dic in database_dict.items()
     }
     log.info("loaded database files")
-
-    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
 
     start = time.time()
     if args.n_processes > 1:
@@ -252,9 +268,9 @@ def build_tier_dsp() -> None:
 
     msg = f"Finished building DSP in {time.time() - start:.2f} seconds"
     log.info(msg)
-    if args.alias_table is not None:
+    if alias_map is not None:
         log.info("Creating alias table")
-        alias_table(args.output, args.alias_table)
+        alias_table(args.output, alias_map)
 
 
 def build_tier_dsp_single_channel() -> None:
@@ -315,9 +331,9 @@ def build_tier_dsp_single_channel() -> None:
     argparser.add_argument("--output", help="output file")
     args = argparser.parse_args()
 
-    df_configs = TextDB(args.configs, lazy=True)
-    config_dict = df_configs.on(args.timestamp, system=args.datatype).snakemake_rules
-    config_dict = config_dict[f"tier_{args.tier}"]
+    config_dict = get_rule_config(
+        args.configs, f"tier_{args.tier}", args.timestamp, args.datatype
+    )
     config_dict = (
         config_dict[args.channel]
         if args.channel is not None and args.channel in config_dict
@@ -325,6 +341,9 @@ def build_tier_dsp_single_channel() -> None:
     )
 
     log = build_log(config_dict, args.log, fallback=__name__)
+
+    check_input_files(args.input, "--input")
+    prepare_output_paths(args.output)
 
     settings_dict = config_dict.options.get("settings", {})
     if isinstance(settings_dict, str):
@@ -338,6 +357,12 @@ def build_tier_dsp_single_channel() -> None:
         for par_file in args.pars_file
         if Path(par_file).suffix in (".json", ".yaml", ".yml")
     ]
+    if args.pars_file and not db_files:
+        msg = (
+            f"--pars-file: none of the provided files {args.pars_file} has a "
+            ".json/.yaml/.yml extension"
+        )
+        raise ValueError(msg)
 
     database_dict = _replace_list_with_array(
         Props.read_from(db_files, subst_pathvar=True)
@@ -347,8 +372,6 @@ def build_tier_dsp_single_channel() -> None:
         if args.channel is not None and args.channel in database_dict
         else database_dict
     )
-
-    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
 
     start = time.time()
 

--- a/src/legenddataflowscripts/tier/hit.py
+++ b/src/legenddataflowscripts/tier/hit.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import argparse
-import json
 import time
-from pathlib import Path
 
 import lh5
-from dbetto import TextDB
 from dbetto.catalog import Props
 from pygama.hit.build_hit import build_hit
 
-from ..utils import alias_table, build_log
+from ..utils import (
+    alias_table,
+    build_log,
+    check_input_files,
+    get_rule_config,
+    parse_json_arg,
+    prepare_output_paths,
+)
 
 
 def build_tier_hit() -> None:
@@ -65,15 +69,20 @@ def build_tier_hit() -> None:
     argparser.add_argument("--output")
     args = argparser.parse_args()
 
-    table_map = json.loads(args.table_map)
-
-    df_config = (
-        TextDB(args.configs, lazy=True)
-        .on(args.timestamp, system=args.datatype)
-        .snakemake_rules[f"tier_{args.tier}"]
+    df_config = get_rule_config(
+        args.configs, f"tier_{args.tier}", args.timestamp, args.datatype
     )
     log = build_log(df_config, args.log, fallback=__name__)
     log.info("initializing")
+
+    table_map = parse_json_arg(args.table_map, "--table-map")
+    alias_map = (
+        parse_json_arg(args.alias_table, "--alias-table")
+        if args.alias_table is not None
+        else None
+    )
+    check_input_files(args.input, "--input")
+    prepare_output_paths(args.output)
 
     settings_dict = df_config.options.get("settings", {})
 
@@ -111,13 +120,12 @@ def build_tier_hit() -> None:
 
     log.info("running build_hit()...")
     start = time.time()
-    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     build_hit(args.input, lh5_tables_config=channel_dict, outfile=args.output)
     msg = f"Hit built in {time.time() - start:.2f} seconds"
     log.info(msg)
-    if args.alias_table is not None:
+    if alias_map is not None:
         log.info("Creating alias table")
-        alias_table(args.output, args.alias_table)
+        alias_table(args.output, alias_map)
 
 
 def build_tier_hit_single_channel() -> None:
@@ -171,13 +179,14 @@ def build_tier_hit_single_channel() -> None:
     argparser.add_argument("--output")
     args = argparser.parse_args()
 
-    df_config = (
-        TextDB(args.configs, lazy=True)
-        .on(args.timestamp, system=args.datatype)
-        .snakemake_rules[f"tier_{args.tier}"]
+    df_config = get_rule_config(
+        args.configs, f"tier_{args.tier}", args.timestamp, args.datatype
     )
     log = build_log(df_config, args.log, fallback=__name__)
     log.info("initializing")
+
+    check_input_files(args.input, "--input")
+    prepare_output_paths(args.output)
 
     settings_dict = df_config.options.get("settings", {})
 
@@ -203,7 +212,6 @@ def build_tier_hit_single_channel() -> None:
 
     log.info("running build_hit()...")
     start = time.time()
-    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     build_hit(args.input, hit_config=hit_cfg, outfile=args.output)
     msg = f"Hit built in {time.time() - start:.2f} seconds"
     log.info(msg)

--- a/src/legenddataflowscripts/tier/hit.py
+++ b/src/legenddataflowscripts/tier/hit.py
@@ -4,6 +4,7 @@ import argparse
 import time
 
 import lh5
+import numpy as np
 from dbetto.catalog import Props
 from pygama.hit.build_hit import build_hit
 
@@ -15,6 +16,33 @@ from ..utils import (
     parse_json_arg,
     prepare_output_paths,
 )
+
+
+def _cast_op_params_f32(hit_cfg: dict) -> dict:
+    """Cast float operation parameters to float32, in place.
+
+    Calibration parameters load from the pars YAML as python (64-bit)
+    floats, and ``Table.eval``/numexpr promotes ``float32-array x
+    float64-scalar`` to float64 — making every derived hit column float64
+    even when the DSP inputs are float32.  YAML cannot express float32, so
+    the cast has to happen here, after loading.  Operations whose
+    expressions reference genuine float64 columns (e.g. ``timestamp``)
+    still promote to float64, which is correct.
+    """
+
+    def cast(v):
+        if isinstance(v, float):
+            return np.float32(v)
+        if isinstance(v, list):
+            return [cast(x) for x in v]
+        return v
+
+    for info in hit_cfg.get("operations", {}).values():
+        pars = info.get("parameters")
+        if isinstance(pars, dict):
+            for key, val in pars.items():
+                pars[key] = cast(val)
+    return hit_cfg
 
 
 def build_tier_hit() -> None:
@@ -106,6 +134,7 @@ def build_tier_hit() -> None:
 
         # get pars (to override hit config)
         hit_cfg = Props.add_to(hit_cfg, pars_dict.get(chan, {}).copy())
+        hit_cfg = _cast_op_params_f32(hit_cfg)
 
         if chan not in table_map:
             continue
@@ -209,6 +238,7 @@ def build_tier_hit_single_channel() -> None:
 
     hit_cfg = Props.read_from(chan_cfg_map)
     hit_cfg = Props.add_to(hit_cfg, pars_dict.copy())
+    hit_cfg = _cast_op_params_f32(hit_cfg)
 
     log.info("running build_hit()...")
     start = time.time()

--- a/src/legenddataflowscripts/utils/__init__.py
+++ b/src/legenddataflowscripts/utils/__init__.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from .alias_table import alias_table
 from .cfgtools import get_channel_config, get_rule_config, require_config_keys
 from .convert_np import convert_dict_np_to_float
-from .files import expand_filelist
+from .files import (
+    check_input_files,
+    expand_filelist,
+    parse_json_arg,
+    prepare_output_paths,
+)
 from .log import build_log
 from .plot_dict import fill_plot_dict
 from .pulser_removal import check_pulser_mask, get_pulser_mask
@@ -11,6 +16,7 @@ from .pulser_removal import check_pulser_mask, get_pulser_mask
 __all__ = [
     "alias_table",
     "build_log",
+    "check_input_files",
     "check_pulser_mask",
     "convert_dict_np_to_float",
     "expand_filelist",
@@ -18,5 +24,7 @@ __all__ = [
     "get_channel_config",
     "get_pulser_mask",
     "get_rule_config",
+    "parse_json_arg",
+    "prepare_output_paths",
     "require_config_keys",
 ]

--- a/src/legenddataflowscripts/utils/cfgtools.py
+++ b/src/legenddataflowscripts/utils/cfgtools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 
 from dbetto import TextDB
 
@@ -81,6 +82,9 @@ def get_rule_config(configs_path, rule_name, timestamp, datatype):
     missing key names the rule, timestamp, datatype and config path instead
     of raising a bare :class:`KeyError`.
     """
+    if not Path(configs_path).is_dir():
+        msg = f"config directory {configs_path} does not exist"
+        raise FileNotFoundError(msg)
     configs = TextDB(configs_path, lazy=True).on(timestamp, category=datatype)
     try:
         return configs["snakemake_rules"][rule_name]

--- a/src/legenddataflowscripts/utils/files.py
+++ b/src/legenddataflowscripts/utils/files.py
@@ -1,11 +1,41 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
 
 
-def expand_filelist(files, argname="--files"):
+def check_input_files(files, argname="input") -> None:
+    """Check that all input files exist, raising a named error otherwise.
+
+    Parameters
+    ----------
+    files : str, pathlib.Path, list, or None
+        Input file path(s) to check. ``None`` is a no-op (for optional
+        arguments that were not provided).
+    argname : str
+        Name of the CLI argument, used in the error message.
+
+    Raises
+    ------
+    FileNotFoundError
+        Naming *argname* and every missing path (up to five, plus a count
+        of any further ones).
+    """
+    if files is None:
+        return
+    if isinstance(files, str | Path):
+        files = [files]
+    missing = [str(file) for file in files if not Path(file).is_file()]
+    if missing:
+        shown = ", ".join(missing[:5])
+        extra = f" (and {len(missing) - 5} more)" if len(missing) > 5 else ""
+        msg = f"{argname}: input file(s) not found: {shown}{extra}"
+        raise FileNotFoundError(msg)
+
+
+def expand_filelist(files, argname="--files", check_exists=True):
     """Expand a CLI file argument that may be a single ``.filelist`` file.
 
     Parameters
@@ -16,6 +46,9 @@ def expand_filelist(files, argname="--files"):
         line.
     argname : str
         Name of the CLI argument, used in error messages.
+    check_exists : bool
+        When ``True`` (the default) every resulting file path is checked
+        for existence via :func:`check_input_files`.
 
     Returns
     -------
@@ -32,4 +65,37 @@ def expand_filelist(files, argname="--files"):
             msg = f"{argname}: filelist {files[0]} is empty"
             raise ValueError(msg)
         files = expanded
-    return sorted(np.unique(files))
+    files = sorted(np.unique(files))
+    if check_exists:
+        check_input_files(files, argname)
+    return files
+
+
+def prepare_output_paths(*paths) -> None:
+    """Create the parent directories of the given output paths.
+
+    Call early in a script, before any expensive computation, so that an
+    unwritable output location fails up front instead of after the work is
+    done. ``None`` entries (optional outputs that were not requested) are
+    skipped.
+    """
+    for path in paths:
+        if path is not None:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_json_arg(value, argname):
+    """Parse a JSON-encoded CLI argument, naming the argument on failure.
+
+    Parameters
+    ----------
+    value : str
+        The JSON string to parse.
+    argname : str
+        Name of the CLI argument, used in the error message.
+    """
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as err:
+        msg = f"{argname} is not valid JSON: {err}"
+        raise ValueError(msg) from None

--- a/src/legenddataflowscripts/workflow/filedb.py
+++ b/src/legenddataflowscripts/workflow/filedb.py
@@ -9,6 +9,8 @@ import numpy as np
 from dbetto.catalog import Props
 from pygama.flow.file_db import FileDB
 
+from ..utils import prepare_output_paths
+
 
 def build_filedb() -> None:
     """Build a :class:`pygama.flow.file_db.FileDB` from a directory scan.
@@ -55,8 +57,6 @@ def build_filedb() -> None:
     argparser.add_argument("--assume-nonsparse", action="store_true")
     args = argparser.parse_args()
 
-    config = Props.read_from(args.config)
-
     if args.log is not None:
         Path(args.log).parent.mkdir(parents=True, exist_ok=True)
         logging.basicConfig(level=logging.DEBUG, filename=args.log, filemode="w")
@@ -70,6 +70,10 @@ def build_filedb() -> None:
     logging.getLogger("h5py._conv").setLevel(logging.INFO)
 
     log = logging.getLogger(__name__)
+
+    prepare_output_paths(args.output)
+
+    config = Props.read_from(args.config)
 
     if args.ignore_keys is not None:
         ignore_dict = Props.read_from(args.ignore_keys)

--- a/tests/test_build_tier_hit.py
+++ b/tests/test_build_tier_hit.py
@@ -1,0 +1,169 @@
+"""Tests for the build-tier-hit float32 parameter cast.
+
+Calibration parameters load from the pars YAML as python (64-bit) floats,
+which makes ``Table.eval`` promote every derived hit column to float64 even
+when the DSP inputs are float32.  ``_cast_op_params_f32`` casts them at load
+time; these tests cover the helper and the end-to-end effect through the
+``build-tier-hit`` entry point on a synthetic float32 DSP file.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+
+import lh5
+import numpy as np
+import pytest
+import yaml
+from lgdo import Array, Table
+
+from legenddataflowscripts.tier.hit import _cast_op_params_f32, build_tier_hit
+
+CHANNEL = "ch1084803"
+
+
+def test_cast_op_params_f32_types():
+    cfg = {
+        "operations": {
+            "x_cal": {
+                "expression": "a + b*x",
+                "parameters": {
+                    "a": 0.5,
+                    "b": 2,
+                    "flag": True,
+                    "name": "cal",
+                    "poly": [1.0, 2.5, 3],
+                },
+            },
+            "no_pars": {"expression": "x*x"},
+        }
+    }
+    out = _cast_op_params_f32(cfg)
+    pars = out["operations"]["x_cal"]["parameters"]
+    assert pars["a"].dtype == np.float32
+    # ints, bools and strings are left untouched
+    assert pars["b"] == 2
+    assert isinstance(pars["b"], int)
+    assert pars["flag"] is True
+    assert pars["name"] == "cal"
+    # floats inside lists are cast, ints preserved
+    assert pars["poly"][0].dtype == np.float32
+    assert isinstance(pars["poly"][2], int)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Synthetic f32 DSP file + minimal rule-config tree for tier_hit."""
+    dsp = tmp_path / "dsp.lh5"
+    rng = np.random.default_rng(42)
+    energies = rng.uniform(100, 3000, 500).astype("float32")
+    lh5.LH5Store().write(
+        Table(col_dict={"cuspEmax": Array(energies)}),
+        "dsp",
+        str(dsp),
+        group=CHANNEL,
+        wo_mode="overwrite_file",
+    )
+
+    cfgdir = tmp_path / "configs"
+    cfgdir.mkdir()
+    (cfgdir / "hit_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "outputs": ["cuspEmax_cal"],
+                "operations": {
+                    "cuspEmax_cal": {
+                        "expression": "a + b*cuspEmax",
+                        "parameters": {"a": 0.25, "b": 0.13},
+                    }
+                },
+            }
+        )
+    )
+    (cfgdir / "logging.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "disable_existing_loggers": False,
+                "handlers": {
+                    "dataflow": {
+                        "class": "logging.FileHandler",
+                        "level": "INFO",
+                        "filename": "__auto__",
+                        "mode": "a",
+                    }
+                },
+                "loggers": {
+                    "prod": {"level": "INFO", "handlers": ["dataflow"]},
+                },
+            }
+        )
+    )
+    (cfgdir / "cfg.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "snakemake_rules": {
+                    "tier_hit": {
+                        "inputs": {"hit_config": {"__default__": "$_/hit_config.yaml"}},
+                        "options": {"logging": "$_/logging.yaml", "logger": "prod"},
+                    }
+                }
+            }
+        )
+    )
+    (cfgdir / "validity.yaml").write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "valid_from": "20220101T000000Z",
+                    "mode": "reset",
+                    "apply": ["cfg.yaml"],
+                },
+                {
+                    "valid_from": "20220101T000000Z",
+                    "category": "cal",
+                    "mode": "reset",
+                    "apply": ["cfg.yaml"],
+                },
+            ]
+        )
+    )
+    return {"dsp": dsp, "configs": cfgdir, "energies": energies, "tmp": tmp_path}
+
+
+def test_build_tier_hit_outputs_float32(workspace, monkeypatch):
+    out = workspace["tmp"] / "hit.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build-tier-hit",
+            "--input",
+            str(workspace["dsp"]),
+            "--configs",
+            str(workspace["configs"]),
+            "--table-map",
+            json.dumps({CHANNEL: f"{CHANNEL}/dsp"}),
+            "--datatype",
+            "cal",
+            "--timestamp",
+            "20230101T000000Z",
+            "--tier",
+            "hit",
+            "--output",
+            str(out),
+            "--log",
+            str(workspace["tmp"] / "hit.log"),
+        ],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        build_tier_hit()
+
+    col = lh5.read(f"{CHANNEL}/hit/cuspEmax_cal", str(out))
+    # float parameters were cast, so the f32 input column stays f32
+    assert col.nda.dtype == np.dtype("float32")
+    ref = 0.25 + 0.13 * workspace["energies"].astype("float64")
+    np.testing.assert_allclose(col.nda, ref, rtol=5e-6)

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -13,11 +13,14 @@ import yaml
 from legenddataflowscripts.utils import (
     alias_table,
     build_log,
+    check_input_files,
     check_pulser_mask,
     expand_filelist,
     get_channel_config,
     get_pulser_mask,
     get_rule_config,
+    parse_json_arg,
+    prepare_output_paths,
     require_config_keys,
 )
 
@@ -46,13 +49,65 @@ def test_require_config_keys():
 
 
 def test_expand_filelist_plain_files():
-    assert expand_filelist(["b.lh5", "a.lh5", "b.lh5"]) == ["a.lh5", "b.lh5"]
+    assert expand_filelist(["b.lh5", "a.lh5", "b.lh5"], check_exists=False) == [
+        "a.lh5",
+        "b.lh5",
+    ]
 
 
 def test_expand_filelist_from_filelist(tmp_path):
+    for name in ("a.lh5", "b.lh5"):
+        (tmp_path / name).touch()
     filelist = tmp_path / "cal.filelist"
-    filelist.write_text("b.lh5\n\na.lh5\n  \nb.lh5\n")
-    assert expand_filelist([str(filelist)]) == ["a.lh5", "b.lh5"]
+    filelist.write_text(f"{tmp_path}/b.lh5\n\n{tmp_path}/a.lh5\n  \n{tmp_path}/b.lh5\n")
+    assert expand_filelist([str(filelist)]) == [
+        f"{tmp_path}/a.lh5",
+        f"{tmp_path}/b.lh5",
+    ]
+
+
+def test_expand_filelist_missing_members(tmp_path):
+    filelist = tmp_path / "cal.filelist"
+    filelist.write_text("missing1.lh5\nmissing2.lh5\n")
+    with pytest.raises(FileNotFoundError, match="--files: input file"):
+        expand_filelist([str(filelist)])
+
+
+def test_check_input_files(tmp_path):
+    existing = tmp_path / "in.lh5"
+    existing.touch()
+
+    check_input_files(None)
+    check_input_files(str(existing), "--input")
+    check_input_files([str(existing)], "--input")
+
+    with pytest.raises(FileNotFoundError, match="--input: input file"):
+        check_input_files(str(tmp_path / "gone.lh5"), "--input")
+
+    # all missing files are aggregated, truncated after five
+    missing = [str(tmp_path / f"m{i}.lh5") for i in range(7)]
+    with pytest.raises(FileNotFoundError, match=r"\(and 2 more\)"):
+        check_input_files(missing, "--files")
+
+
+def test_prepare_output_paths(tmp_path):
+    out1 = tmp_path / "a" / "b" / "out.yaml"
+    out2 = tmp_path / "c" / "out.pkl"
+    prepare_output_paths(str(out1), None, str(out2))
+    assert out1.parent.is_dir()
+    assert out2.parent.is_dir()
+
+
+def test_parse_json_arg():
+    assert parse_json_arg('{"ch1": "ch1/raw"}', "--table-map") == {"ch1": "ch1/raw"}
+
+    with pytest.raises(ValueError, match="--table-map is not valid JSON"):
+        parse_json_arg("{not json}", "--table-map")
+
+
+def test_get_rule_config_missing_dir(tmp_path):
+    with pytest.raises(FileNotFoundError, match="config directory"):
+        get_rule_config(tmp_path / "nope", "tier_dsp", "20230101T000000Z", "cal")
 
 
 def test_expand_filelist_empty_args():


### PR DESCRIPTION
Follow-on to #39: every console script now sanity-checks its inputs up front with named errors, so failures surface at startup instead of deep inside processing or after expensive computation.

## New helpers (`legenddataflowscripts.utils`)

- `check_input_files(files, argname)` — named `FileNotFoundError` aggregating every missing path (truncated after five).
- `expand_filelist(..., check_exists=True)` — files listed **inside** filelists are now existence-checked by default. Previously a missing member failed deep inside `lh5.read`/`load_data`, often after other inputs were loaded and DSP work had begun.
- `prepare_output_paths(*paths)` — output parent dirs are created right after `build_log`, so an unwritable output location fails before the minutes-long calibration/optimisation, not after it.
- `parse_json_arg(value, argname)` — JSON CLI args (`--table-map`, `--alias-table`) fail naming the argument. A malformed `--alias-table` previously failed **after the entire tier build**.
- `get_rule_config` — named error for a nonexistent config directory (dbetto's `TextDB` raises `ValueError("input path is not a valid directory")` without the path).

## Script changes

- **tier/dsp + tier/hit (both entry points)**: rule config resolved via `get_rule_config` (named dir/rule errors instead of the pathless dbetto `ValueError` and bare `KeyError`s); `--table-map`/`--alias-table` parsed right after `build_log`; `--input` checked; named error when all `--pars-file` entries are suffix-filtered away.
- **dplms / eopt / nopt**: `build_log` now runs before the first config read, so those failures get ERROR-token logging; `--peak-file`/`--inplots` checked and output dirs prepared before the optimisation.
- **evtsel**: a wrong `--channel` on `--raw-cal-curve` names the channel and argument.
- **svm**: `--svm-file` existence checked — a bad path was silently embedded into the output pars.
- **svm_build**: `--train-hyperpars` required when `--train-data` is given (previously `Props.read_from(None)`); output dir prepared (was missing entirely).
- **aoe**: `--detector` required when `--override-files` is given — omitting it silently disabled the overrides.
- **ecal**: named errors for `--ctc-dict` entries all filtered away and missing `ctc_params`; fixed the dead `mkdir`-after-`open` on `--results-path`; `--save-path` dir prepared (had no mkdir at all).
- **qc / pz / lq / filedb**: output dirs prepared up front; filedb configures logging before its first file read.

## Also

- **`dbetto>=1.4` pin**: #40 adopted `TextDB.on(category=...)`, which doesn't exist in dbetto 1.3.x still allowed by the previous `>=1.3.6` pin — the test suite fails with `TypeError` on 1.3.7.

## Tests

54 passing (5 new: `check_input_files`, `prepare_output_paths`, `parse_json_arg`, filelist member checking, `get_rule_config` missing-dir). Existing `expand_filelist` tests updated for the existence-check default. legend-dataflow's suite (100 tests) verified green against this branch via its editable install.

Behavior note: `expand_filelist`'s member check is on by default — Snakemake-driven runs are unaffected (inputs are DAG-guaranteed), but hand-run invocations with nonexistent paths now fail at startup with the argument named.

---

Per `AI_POLICY.md`: this contribution was drafted with AI assistance (Claude Code) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
