### PR TITLE
Cast hit-operation float parameters to float32 at load time

### DIFF
--- a/src/legenddataflowscripts/tier/hit.py
+++ b/src/legenddataflowscripts/tier/hit.py
@@ -4,6 +4,7 @@ import argparse
 import time
 
 import lh5
+import numpy as np
 from dbetto.catalog import Props
 from pygama.hit.build_hit import build_hit
 
@@ -15,6 +16,33 @@ from ..utils import (
     parse_json_arg,
     prepare_output_paths,
 )
+
+
+def _cast_op_params_f32(hit_cfg: dict) -> dict:
+    """Cast float operation parameters to float32, in place.
+
+    Calibration parameters load from the pars YAML as python (64-bit)
+    floats, and ``Table.eval``/numexpr promotes ``float32-array x
+    float64-scalar`` to float64 — making every derived hit column float64
+    even when the DSP inputs are float32.  YAML cannot express float32, so
+    the cast has to happen here, after loading.  Operations whose
+    expressions reference genuine float64 columns (e.g. ``timestamp``)
+    still promote to float64, which is correct.
+    """
+
+    def cast(v):
+        if isinstance(v, float):
+            return np.float32(v)
+        if isinstance(v, list):
+            return [cast(x) for x in v]
+        return v
+
+    for info in hit_cfg.get("operations", {}).values():
+        pars = info.get("parameters")
+        if isinstance(pars, dict):
+            for key, val in pars.items():
+                pars[key] = cast(val)
+    return hit_cfg
 
 
 def build_tier_hit() -> None:
@@ -106,6 +134,7 @@ def build_tier_hit() -> None:
 
         # get pars (to override hit config)
         hit_cfg = Props.add_to(hit_cfg, pars_dict.get(chan, {}).copy())
+        hit_cfg = _cast_op_params_f32(hit_cfg)
 
         if chan not in table_map:
             continue
@@ -209,6 +238,7 @@ def build_tier_hit_single_channel() -> None:
 
     hit_cfg = Props.read_from(chan_cfg_map)
     hit_cfg = Props.add_to(hit_cfg, pars_dict.copy())
+    hit_cfg = _cast_op_params_f32(hit_cfg)
 
     log.info("running build_hit()...")
     start = time.time()

--- a/tests/test_build_tier_hit.py
+++ b/tests/test_build_tier_hit.py
@@ -1,0 +1,169 @@
+"""Tests for the build-tier-hit float32 parameter cast.
+
+Calibration parameters load from the pars YAML as python (64-bit) floats,
+which makes ``Table.eval`` promote every derived hit column to float64 even
+when the DSP inputs are float32.  ``_cast_op_params_f32`` casts them at load
+time; these tests cover the helper and the end-to-end effect through the
+``build-tier-hit`` entry point on a synthetic float32 DSP file.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+
+import lh5
+import numpy as np
+import pytest
+import yaml
+from lgdo import Array, Table
+
+from legenddataflowscripts.tier.hit import _cast_op_params_f32, build_tier_hit
+
+CHANNEL = "ch1084803"
+
+
+def test_cast_op_params_f32_types():
+    cfg = {
+        "operations": {
+            "x_cal": {
+                "expression": "a + b*x",
+                "parameters": {
+                    "a": 0.5,
+                    "b": 2,
+                    "flag": True,
+                    "name": "cal",
+                    "poly": [1.0, 2.5, 3],
+                },
+            },
+            "no_pars": {"expression": "x*x"},
+        }
+    }
+    out = _cast_op_params_f32(cfg)
+    pars = out["operations"]["x_cal"]["parameters"]
+    assert pars["a"].dtype == np.float32
+    # ints, bools and strings are left untouched
+    assert pars["b"] == 2
+    assert isinstance(pars["b"], int)
+    assert pars["flag"] is True
+    assert pars["name"] == "cal"
+    # floats inside lists are cast, ints preserved
+    assert pars["poly"][0].dtype == np.float32
+    assert isinstance(pars["poly"][2], int)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Synthetic f32 DSP file + minimal rule-config tree for tier_hit."""
+    dsp = tmp_path / "dsp.lh5"
+    rng = np.random.default_rng(42)
+    energies = rng.uniform(100, 3000, 500).astype("float32")
+    lh5.LH5Store().write(
+        Table(col_dict={"cuspEmax": Array(energies)}),
+        "dsp",
+        str(dsp),
+        group=CHANNEL,
+        wo_mode="overwrite_file",
+    )
+
+    cfgdir = tmp_path / "configs"
+    cfgdir.mkdir()
+    (cfgdir / "hit_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "outputs": ["cuspEmax_cal"],
+                "operations": {
+                    "cuspEmax_cal": {
+                        "expression": "a + b*cuspEmax",
+                        "parameters": {"a": 0.25, "b": 0.13},
+                    }
+                },
+            }
+        )
+    )
+    (cfgdir / "logging.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "disable_existing_loggers": False,
+                "handlers": {
+                    "dataflow": {
+                        "class": "logging.FileHandler",
+                        "level": "INFO",
+                        "filename": "__auto__",
+                        "mode": "a",
+                    }
+                },
+                "loggers": {
+                    "prod": {"level": "INFO", "handlers": ["dataflow"]},
+                },
+            }
+        )
+    )
+    (cfgdir / "cfg.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "snakemake_rules": {
+                    "tier_hit": {
+                        "inputs": {"hit_config": {"__default__": "$_/hit_config.yaml"}},
+                        "options": {"logging": "$_/logging.yaml", "logger": "prod"},
+                    }
+                }
+            }
+        )
+    )
+    (cfgdir / "validity.yaml").write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "valid_from": "20220101T000000Z",
+                    "mode": "reset",
+                    "apply": ["cfg.yaml"],
+                },
+                {
+                    "valid_from": "20220101T000000Z",
+                    "category": "cal",
+                    "mode": "reset",
+                    "apply": ["cfg.yaml"],
+                },
+            ]
+        )
+    )
+    return {"dsp": dsp, "configs": cfgdir, "energies": energies, "tmp": tmp_path}
+
+
+def test_build_tier_hit_outputs_float32(workspace, monkeypatch):
+    out = workspace["tmp"] / "hit.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build-tier-hit",
+            "--input",
+            str(workspace["dsp"]),
+            "--configs",
+            str(workspace["configs"]),
+            "--table-map",
+            json.dumps({CHANNEL: f"{CHANNEL}/dsp"}),
+            "--datatype",
+            "cal",
+            "--timestamp",
+            "20230101T000000Z",
+            "--tier",
+            "hit",
+            "--output",
+            str(out),
+            "--log",
+            str(workspace["tmp"] / "hit.log"),
+        ],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        build_tier_hit()
+
+    col = lh5.read(f"{CHANNEL}/hit/cuspEmax_cal", str(out))
+    # float parameters were cast, so the f32 input column stays f32
+    assert col.nda.dtype == np.dtype("float32")
+    ref = 0.25 + 0.13 * workspace["energies"].astype("float64")
+    np.testing.assert_allclose(col.nda, ref, rtol=5e-6)


### PR DESCRIPTION
Stacked on #41 (`input-validation`) — only the last commit is new here; retarget/rebase to `main` once #41 merges.

## Motivation

Profiling LEGEND production files showed the pht (hit) tier's float64 columns — 10 calibrated energies, 3 PSD classifiers, 8 QC cut classifiers — account for 83% of the tier's raw bytes and barely compress (gzip ratios 0.84–0.95, they are noise-like mantissas). They are float64 only because the calibration `parameters` load from the pars YAML as python floats, and `Table.eval`/numexpr promotes `float32-array × float64-scalar` to float64. YAML cannot express float32, so the pars files cannot carry the dtype — the cast has to happen at load time.

## Change

`build-tier-hit` casts python-float entries of each operation's `parameters` to `np.float32` after loading/merging the parameter dictionary (`_cast_op_params_f32`), in both the multi-channel and single-channel entry points. Since `build-tier-hit --tier pht` is the same script, this covers the hit and pht tiers. Ints, bools and strings are untouched; floats inside lists are cast.

Operations whose expressions reference genuine float64 columns (e.g. `timestamp`) still promote to float64, which is correct and safe.

## Validation (production p16 pht pars for V05267A over real raw data)

- 48 of 49 float operations become float32; all 23 boolean cut columns bit-identical; NaN patterns identical.
- Every value difference ≤ 5×10⁻⁵ of the column's spread (energies at ~1e-7 relative — ~0.3 eV at 2.6 MeV).
- The single holdout is `AoE_Classifier`: its *generated expression* embeds a `10**-99` division guard (a float64 literal, which also underflows to 0 in float32) — that needs a one-line fix in the A/E calibration generator (pygama), out of scope here.
- Expected effect: ~40% pht file-size reduction (in combination with compression), since the float64 columns dominate the tier.

## Tests

`tests/test_build_tier_hit.py`: unit test of the cast helper's type handling, plus an end-to-end run of the `build-tier-hit` console script over a synthetic float32 DSP file with a minimal rule-config tree, asserting the derived column comes out float32 with values matching a float64 reference at 5e-6.

## Disclosure

Per `AI_POLICY.md`: developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)