### PR TITLE
feat(execenv): pixi mode and deprecation of the execenv layer

### DIFF
--- a/docs/source/callables.rst
+++ b/docs/source/callables.rst
@@ -21,7 +21,10 @@ Workflow Management
      - :func:`~legenddataflowscripts.workflow.execenv.dataflow`
      - Top-level CLI for installing software and executing commands inside the
        data-production environment (supports ``install`` and ``exec``
-       sub-commands).
+       sub-commands). *Deprecated* in favour of managing the cycle's software
+       environment with `pixi <https://pixi.sh>`_: production cycles that omit
+       the ``execenv:`` config section run all commands directly in the
+       ambient (pixi) environment.
    * - ``build-filedb``
      - :func:`~legenddataflowscripts.workflow.filedb.build_filedb`
      - Scan a directory of raw LH5 files and build a

--- a/src/legenddataflowscripts/workflow/execenv.py
+++ b/src/legenddataflowscripts/workflow/execenv.py
@@ -80,9 +80,10 @@ def execenv_prefix(
 
     Note
     ----
-    If *as_string* is ``True``, a space is appended to the returned string.
-    When *config* has no (non-empty) ``execenv`` section — i.e. the cycle's
-    software environment is managed by pixi — the prefix is empty.
+    If *as_string* is ``True``, a space is appended to the returned (non-empty)
+    string. When *config* has no (non-empty) ``execenv`` section — i.e. the
+    cycle's software environment is managed by pixi — the prefix is the empty
+    string, with no trailing space.
     """
     config = AttrsDict(config)
 
@@ -159,10 +160,11 @@ def execenv_pyexe(
 
     Note
     ----
-    If *as_string* is ``True``, a space is appended to the returned string.
-    When *config* has no (non-empty) ``execenv`` section — i.e. the cycle's
-    software environment is managed by pixi — the bare executable name is
-    returned and resolves from the ambient environment's ``PATH``.
+    If *as_string* is ``True``, a space is appended to the returned string
+    (in every mode). When *config* has no (non-empty) ``execenv`` section —
+    i.e. the cycle's software environment is managed by pixi — the bare
+    executable name is returned and resolves from the ambient environment's
+    ``PATH``.
     """
     config = AttrsDict(config)
 

--- a/src/legenddataflowscripts/workflow/execenv.py
+++ b/src/legenddataflowscripts/workflow/execenv.py
@@ -25,6 +25,17 @@ def _execenv2str(cmd_expr: Iterable, cmd_env: Mapping) -> str:
     return " ".join([f"{k}={v}" for k, v in cmd_env.items()]) + " " + " ".join(cmd_expr)
 
 
+def _uses_execenv(config: Mapping) -> bool:
+    """Return whether *config* defines a non-empty ``execenv`` section.
+
+    Production cycles managed by `pixi <https://pixi.sh>`_ omit the
+    ``execenv:`` block entirely: the software environment (including
+    container-image contents) is provided by the ambient pixi environment,
+    so no container prefix or virtualenv path handling is needed.
+    """
+    return bool(config.get("execenv"))
+
+
 def apptainer_env_vars(cmdenv: Mapping) -> list[str]:
     return [f"--env={var}={val}" for var, val in cmdenv.items()]
 
@@ -70,8 +81,13 @@ def execenv_prefix(
     Note
     ----
     If *as_string* is ``True``, a space is appended to the returned string.
+    When *config* has no (non-empty) ``execenv`` section — i.e. the cycle's
+    software environment is managed by pixi — the prefix is empty.
     """
     config = AttrsDict(config)
+
+    if not _uses_execenv(config):
+        return "" if as_string else ([], {})
 
     cmdline = []
     cmdenv = {}
@@ -144,8 +160,14 @@ def execenv_pyexe(
     Note
     ----
     If *as_string* is ``True``, a space is appended to the returned string.
+    When *config* has no (non-empty) ``execenv`` section — i.e. the cycle's
+    software environment is managed by pixi — the bare executable name is
+    returned and resolves from the ambient environment's ``PATH``.
     """
     config = AttrsDict(config)
+
+    if not _uses_execenv(config):
+        return f"{exename} " if as_string else ([exename], {})
 
     cmdline, cmdenv = execenv_prefix(config, as_string=False)
     cmdline.append(f"{config.paths.install}/bin/{exename}")
@@ -285,6 +307,20 @@ def install(args) -> None:
         config_dict, var_values={"_": config_loc}, use_env=True, ignore_missing=False
     )
 
+    if not _uses_execenv(config_dict):
+        msg = (
+            f"{args.config_file} has no 'execenv' section: this production "
+            "cycle's software environment is managed by pixi. Run "
+            "'pixi install' (or 'pixi shell') in the cycle directory instead."
+        )
+        raise SystemExit(msg)
+
+    log.warning(
+        "'dataflow install' is deprecated in favour of managing the cycle's "
+        "software environment with pixi (https://pixi.sh): drop the 'execenv' "
+        "section from the config and run 'pixi install' instead"
+    )
+
     config_dict["execenv"] = _select_execenv(config_dict, args.system, args.config_file)
 
     # path to virtualenv location
@@ -388,6 +424,21 @@ def cmdexec(args) -> None:
         use_env=True,
         ignore_missing=False,
     )
+
+    if not _uses_execenv(config_dict):
+        # pixi-managed cycle: no container prefix and no cycle virtualenv,
+        # just run the command in the ambient (pixi) environment
+        msg = "running: " + " ".join(args.command)
+        log.debug(msg)
+        subprocess.run(args.command, check=True)
+        return
+
+    log.warning(
+        "'dataflow exec' is deprecated in favour of managing the cycle's "
+        "software environment with pixi (https://pixi.sh): drop the 'execenv' "
+        "section from the config and use 'pixi run' instead"
+    )
+
     config_dict["execenv"] = _select_execenv(config_dict, args.system, args.config_file)
 
     exe_path = Path(config_dict.paths.install).resolve() / "bin"

--- a/tests/test_execenv.py
+++ b/tests/test_execenv.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import os
+import subprocess
 import sys
 
 import pytest
+import yaml
 from dbetto import AttrsDict
 
 from legenddataflowscripts.workflow import execenv
@@ -101,6 +104,96 @@ def test_execenv_pyexe(config):
         "--image=legendexp/legend-base:latest "
         ".snakemake/software/bin/dio-boe "
     )
+
+
+def test_execenv_prefix_pixi_mode():
+    # a config without an execenv section is a pixi-managed cycle: no
+    # container prefix, no env exports
+    for cfg in ({}, {"paths": {"install": "x"}}, {"execenv": {}}, {"execenv": None}):
+        assert execenv.execenv_prefix(cfg, as_string=True) == ""
+        assert execenv.execenv_prefix(cfg, as_string=False) == ([], {})
+
+
+def test_execenv_pyexe_pixi_mode():
+    # ... and executables resolve from the ambient environment's PATH
+    for cfg in ({}, {"paths": {"install": "x"}}, {"execenv": {}}):
+        assert execenv.execenv_pyexe(cfg, "dio-boe") == "dio-boe "
+        assert execenv.execenv_pyexe(cfg, "dio-boe", as_string=False) == (
+            ["dio-boe"],
+            {},
+        )
+
+
+def test_install_refuses_pixi_managed_cycle(tmp_path):
+    cfg = tmp_path / "dataflow-config.yaml"
+    cfg.write_text(yaml.dump({"paths": {"install": str(tmp_path / "venv")}}))
+
+    args = type(
+        "Args",
+        (),
+        {"config_file": str(cfg), "system": "bare", "remove": False, "editable": False},
+    )()
+    with pytest.raises(SystemExit, match="managed by pixi"):
+        execenv.install(args)
+
+
+def test_cmdexec_pixi_mode_runs_bare_command(monkeypatch, tmp_path):
+
+    cfg = tmp_path / "dataflow-config.yaml"
+    cfg.write_text(yaml.dump({"paths": {"install": str(tmp_path / "venv")}}))
+
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls["cmd"] = cmd
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    args = type(
+        "Args",
+        (),
+        {"config_file": str(cfg), "system": "bare", "command": ["echo", "hi"]},
+    )()
+    execenv.cmdexec(args)
+
+    assert calls["cmd"] == ["echo", "hi"]
+    # no env override: the ambient (pixi) environment is used as-is
+    assert "env" not in calls["kwargs"]
+
+
+def test_install_warns_deprecation_with_execenv(monkeypatch, tmp_path, caplog):
+
+    cfg = tmp_path / "dataflow-config.yaml"
+    cfg.write_text(
+        yaml.dump(
+            {
+                "paths": {"install": str(tmp_path / "venv")},
+                "execenv": {"bare": {"env": {"VAR1": "val1"}}},
+            }
+        )
+    )
+
+    # stop before any real venv work happens
+    def _stop(*_args, **_kwargs):
+        msg = "stop-here"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(execenv.subprocess, "run", _stop)
+
+    args = type(
+        "Args",
+        (),
+        {"config_file": str(cfg), "system": "bare", "remove": False, "editable": False},
+    )()
+    with (
+        caplog.at_level(logging.WARNING, logger="legenddataflowscripts"),
+        pytest.raises(RuntimeError, match="stop-here"),
+    ):
+        execenv.install(args)
+
+    assert "deprecated" in caplog.text
+    assert "pixi" in caplog.text
 
 
 def test_dataflow_no_subcommand(monkeypatch, capsys):

--- a/tests/test_execenv.py
+++ b/tests/test_execenv.py
@@ -116,7 +116,7 @@ def test_execenv_prefix_pixi_mode():
 
 def test_execenv_pyexe_pixi_mode():
     # ... and executables resolve from the ambient environment's PATH
-    for cfg in ({}, {"paths": {"install": "x"}}, {"execenv": {}}):
+    for cfg in ({}, {"paths": {"install": "x"}}, {"execenv": {}}, {"execenv": None}):
         assert execenv.execenv_pyexe(cfg, "dio-boe") == "dio-boe "
         assert execenv.execenv_pyexe(cfg, "dio-boe", as_string=False) == (
             ["dio-boe"],


### PR DESCRIPTION
Companion to legend-exp/legend-dataflow#163 (issue legend-exp/legend-dataflow#135, "pixi/conda envs — would allow us to remove the ugly execenv code"). Staged first step: pixi mode + deprecation, no API removals.

## Changes

When a production cycle's dataflow-config has **no (non-empty) `execenv:` section**, the software environment is assumed to be managed by [pixi](https://pixi.sh):

- `execenv_prefix` returns an empty prefix (no container command, no env exports) — the ambient pixi environment is authoritative (its `[tool.pixi.activation.env]` replaces the execenv env-var layer).
- `execenv_pyexe` returns the bare executable name, resolving console scripts from the ambient `PATH` instead of `<cycle>/.snakemake/.../venv/bin/`. All 88 call sites in legend-dataflow's rules therefore work unchanged in both modes.
- `dataflow exec` runs the command directly in the ambient environment; `dataflow install` exits with a pointer to `pixi install`.
- Both CLI sub-commands log a deprecation warning on the legacy (execenv-present) path; legacy behaviour is otherwise byte-identical (covered by the existing prefix/pyexe tests, unchanged).
- `subst_vars_in_snakemake_config` already tolerates a missing `execenv` key — no change needed there.

## Tests

Six new tests: pixi-mode prefix/pyexe for empty/missing/None `execenv` variants, `install` refusing a pixi-managed cycle, `exec` running the bare command without env overrides, and the deprecation warning on the legacy install path. Full unit suite: 54 passed; docs table updated.

Cross-repo verification: inside the companion PR's `pixi shell`, console scripts resolve on `PATH` and pixi-mode `execenv_pyexe(cfg, "build-tier-dsp")` returns the runnable bare command.

## Follow-up (separate major change)

Delete the execenv machinery and the `dataflow install`/`exec` sub-commands entirely once the parent repo's rule call sites are rewritten and container sites have migrated to pixi.

Disclosure per `AI_POLICY.md`: developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)