### PR TITLE
fix(par-hit): align aoe entry checks and naming with the params schema

### DIFF
--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -132,6 +132,11 @@ def run_aoe_calibration(
         config = Props.read_from(config)
 
     if config.get("run_aoe", True) is True:
+        require_config_keys(
+            config,
+            ["cal_energy_param", "cut_field", "params"],
+            "aoe calibration config",
+        )
         aoe_objs = {}
         aoe_plot_dict = {}
         out_dicts = {}
@@ -164,6 +169,11 @@ def run_aoe_calibration(
                     return x * np.nan
 
         for name, param_config in config["params"].items():
+            require_config_keys(
+                param_config,
+                ["current_param", "energy_param"],
+                f"aoe calibration config params entry '{name}'",
+            )
             if "plot_options" in param_config:
                 for field, item in param_config["plot_options"].items():
                     param_config["plot_options"][field]["function"] = eval(
@@ -398,7 +408,12 @@ def par_geds_hit_aoe() -> None:
             "tp_99",
             "timestamp",
         ]
-        for param_config in kwarg_dict["params"].values():
+        for name, param_config in kwarg_dict["params"].items():
+            require_config_keys(
+                param_config,
+                ["current_param", "energy_param"],
+                f"aoe config params entry '{name}' ({args.config_file})",
+            )
             params.append(param_config["current_param"])
             params.append(param_config["energy_param"])
             if "dt_param" in param_config:

--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -103,8 +103,13 @@ def run_aoe_calibration(
         ``{timestamp: plot_dict}`` mapping of existing plot dictionaries.
     config : dict or str or list
         A/E calibration configuration.  Must contain ``run_aoe`` (bool),
-        ``current_param``, ``energy_param``, ``cal_energy_param``,
-        ``cut_field``, and ``threshold``.
+        ``cal_energy_param``, ``cut_field``, and ``params`` — a mapping of
+        ``{name: param_config}`` with one entry per A/E parameter to
+        calibrate.  Each *param_config* must contain ``current_param`` and
+        ``energy_param``; optional keys are ``dt_param``, ``dt_corr``,
+        ``dep_correct``, ``dt_cut``, ``pdf``, ``mean_func``, ``sigma_func``,
+        ``high_cut_val``, ``suffix`` (appended to the output parameter names
+        so entries don't collide), and ``plot_options``.
     debug_mode : bool
         Activates additional diagnostic output in :class:`~pygama.pargen.AoE_cal.CalAoE`.
         Defaults to ``False``.
@@ -179,11 +184,8 @@ def run_aoe_calibration(
                     exp, local_dict=cut_dict[next(iter(cut_dict))]["parameters"]
                 )
 
-            initial_param = (
-                "AoE_uncorr"
-                if param_config.get("suffix", None) is None
-                else f"AoE_Uncorr_{param_config['suffix']}"
-            )
+            suffix = param_config.get("suffix", None)
+            initial_param = "AoE_Uncorr" if suffix is None else f"AoE_Uncorr_{suffix}"
             data[initial_param] = (
                 data[param_config["current_param"]] / data[param_config["energy_param"]]
             )
@@ -219,7 +221,7 @@ def run_aoe_calibration(
                 data,
                 initial_param,
                 override_dict=override_dict,
-                suffix=param_config.get("suffix", None),
+                **({} if suffix is None else {"suffix": suffix}),
             )
 
             msg = f"A/E calibration completed in {time.time() - start:.2f} seconds"
@@ -386,7 +388,7 @@ def par_geds_hit_aoe() -> None:
     if kwarg_dict["run_aoe"] is True:
         require_config_keys(
             kwarg_dict,
-            ["current_param", "energy_param", "cal_energy_param", "cut_field"],
+            ["cal_energy_param", "cut_field", "threshold", "params"],
             f"aoe config ({args.config_file})",
         )
         params = [


### PR DESCRIPTION
Three small follow-ups to the multi-parameter A/E config schema merged in #42:

- `par-geds-hit-aoe` still required top-level `current_param`/`energy_param`, which no longer exist in `params`-style configs — any migrated config failed the up-front check. It now requires `cal_energy_param`/`cut_field`/`threshold`/`params` (the per-entry keys are read inside the params loop).
- Restores the historical `AoE_Uncorr` spelling for the unsuffixed initial parameter — the params rewrite introduced lowercase `AoE_uncorr`, silently renaming the hit-level operation in output par files.
- Passes the `suffix` kwarg to `CalAoE.calibrate` only when a suffix is actually configured, so unsuffixed configs keep working with released pygama versions that predate suffix support (legend-exp/pygama#707 / the `aoe` branch).

The `run_aoe_calibration` docstring is updated to describe the `params` schema.

Per `AI_POLICY.md`: developed with AI assistance (Claude); reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)