### PR TITLE
feat(par-hit): multi-parameter LQ calibration via params config schema

### DIFF
--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -432,7 +432,12 @@ def par_geds_hit_aoe() -> None:
             "tp_99",
             "timestamp",
         ]
-        for param_config in kwarg_dict["params"].values():
+        for name, param_config in kwarg_dict["params"].items():
+            require_config_keys(
+                param_config,
+                ["current_param", "energy_param"],
+                f"aoe config params entry '{name}' ({args.config_file})",
+            )
             params.append(param_config["current_param"])
             params.append(param_config["energy_param"])
             if "dt_param" in param_config:

--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -104,51 +104,52 @@ def run_aoe_calibration(
         ``{timestamp: plot_dict}`` mapping of existing plot dictionaries.
     config : dict or str or list
         A/E calibration configuration.  Must contain ``run_aoe`` (bool),
-        ``current_param``, ``energy_param``, ``cal_energy_param``,
-        ``cut_field``, and ``threshold``.  Optional key ``use_log_pdf``
-        (bool, default false): build the unbinned A/E and survival-fraction
-        fits from the models' log-densities (iminuit ``log=True``) —
-        substantially faster, results differ at machine-precision level;
-        requires a pygama version with ``use_log_pdf`` support (silently
-        ignored otherwise).
+        ``cal_energy_param``, ``cut_field``, and ``params`` — a mapping of
+        ``{name: param_config}`` with one entry per A/E parameter to
+        calibrate.  Each *param_config* must contain ``current_param`` and
+        ``energy_param``; optional keys are ``dt_param``, ``dt_corr``,
+        ``dep_correct``, ``dt_cut``, ``pdf``, ``mean_func``, ``sigma_func``,
+        ``high_cut_val``, ``suffix`` (appended to the output parameter names
+        so entries don't collide), and ``plot_options``.  Optional top-level
+        key ``use_log_pdf`` (bool, default false): build the unbinned A/E
+        and survival-fraction fits from the models' log-densities (iminuit
+        ``log=True``) — substantially faster, results differ at
+        machine-precision level; requires a pygama version with
+        ``use_log_pdf`` support (silently ignored otherwise).
     debug_mode : bool
         Activates additional diagnostic output in :class:`~pygama.pargen.AoE_cal.CalAoE`.
         Defaults to ``False``.
     override_dict : dict, optional
         Per-detector override parameters passed to
-        :meth:`~pygama.pargen.AoE_cal.CalAoE.calibrate`.
+        :meth:`~pygama.pargen.AoE_cal.CalAoE.calibrate`.  With suffixed
+        ``params`` entries the override keys must use the suffixed names.
 
     Returns
     -------
     cal_dicts : dict
         Updated calibration operations mappings.
     out_result_dicts : dict
-        Updated results mappings including A/E results.
+        Updated results mappings; A/E results are nested per ``params``
+        entry under the ``aoe`` key.
     out_object_dicts : dict
-        Updated object mappings including the ``CalAoE`` instance.
+        Updated object mappings including one ``CalAoE`` instance per
+        ``params`` entry.
     out_plot_dicts : dict
-        Updated plot mappings including A/E diagnostic figures.
+        Updated plot mappings including A/E diagnostic figures per
+        ``params`` entry.
     """
     if isinstance(config, str | list):
         config = Props.read_from(config)
 
     if config.get("run_aoe", True) is True:
-        if "plot_options" in config:
-            for field, item in config["plot_options"].items():
-                config["plot_options"][field]["function"] = eval(item["function"])
-
-        if "dt_cut" in config and config["dt_cut"] is not None:
-            cut_dict = config["dt_cut"]["cut"]
-            for tstamp in cal_dicts:
-                cal_dicts[tstamp].update(cut_dict)
-
-            exp = cut_dict[next(iter(cut_dict))]["expression"]
-            for key in cut_dict[next(iter(cut_dict))]["parameters"]:
-                exp = re.sub(f"(?<![a-zA-Z0-9]){key}(?![a-zA-Z0-9])", f"@{key}", exp)
-            data[next(iter(cut_dict))] = data.eval(
-                exp, local_dict=cut_dict[next(iter(cut_dict))]["parameters"]
-            )
-
+        require_config_keys(
+            config,
+            ["cal_energy_param", "cut_field", "params"],
+            "aoe calibration config",
+        )
+        aoe_objs = {}
+        aoe_plot_dict = {}
+        out_dicts = {}
         try:
             eres = copy.deepcopy(
                 results_dicts[next(iter(results_dicts))]["partition_ecal"][
@@ -177,13 +178,6 @@ def run_aoe_calibration(
                 def eres_func(x):
                     return x * np.nan
 
-        data["AoE_Uncorr"] = (
-            data[config["current_param"]] / data[config["energy_param"]]
-        )
-
-        start = time.time()
-        log.info("calibrating A/E")
-
         # opt-in: build the unbinned A/E and survival-fraction fits from the
         # models' log-densities (iminuit log=True mode) — faster, results
         # differ at machine-precision level. Needs a pygama version with
@@ -193,59 +187,106 @@ def run_aoe_calibration(
             log.warning("installed pygama does not support use_log_pdf, ignoring")
             use_log_pdf = False
 
-        aoe = CalAoE(
-            cal_dicts=cal_dicts,
-            cal_energy_param=config["cal_energy_param"],
-            eres_func=eres_func,
-            pdf=eval(config.get("pdf", "aoe_peak")),
-            mean_func=eval(config.get("mean_func", "Pol1")),
-            sigma_func=eval(config.get("sigma_func", "SigmaFit")),
-            selection_string=f"{config['cut_field']}&(~is_pulser)",
-            dt_corr=config.get("dt_corr", False),
-            dep_correct=config.get("dep_correct", False),
-            dt_cut=config.get("dt_cut", None),
-            dt_param=config.get("dt_param", 3),
-            high_cut_val=config.get("high_cut_val", 3),
-            compt_bands_width=config.get("debug_mode", 20),
-            debug_mode=debug_mode | config.get("debug_mode", False),
-            **({"use_log_pdf": True} if use_log_pdf else {}),
-        )
-        aoe.update_cal_dicts(
-            {
-                "AoE_Uncorr": {
-                    "expression": f"{config['current_param']}/{config['energy_param']}",
-                    "parameters": {},
+        for name, param_config in config["params"].items():
+            require_config_keys(
+                param_config,
+                ["current_param", "energy_param"],
+                f"aoe calibration config params entry '{name}'",
+            )
+            if "plot_options" in param_config:
+                for field, item in param_config["plot_options"].items():
+                    param_config["plot_options"][field]["function"] = eval(
+                        item["function"]
+                    )
+
+            if "dt_cut" in param_config and param_config["dt_cut"] is not None:
+                cut_dict = param_config["dt_cut"]["cut"]
+                for tstamp in cal_dicts:
+                    cal_dicts[tstamp].update(cut_dict)
+
+                exp = cut_dict[next(iter(cut_dict))]["expression"]
+                for key in cut_dict[next(iter(cut_dict))]["parameters"]:
+                    exp = re.sub(
+                        f"(?<![a-zA-Z0-9]){key}(?![a-zA-Z0-9])", f"@{key}", exp
+                    )
+                data[next(iter(cut_dict))] = data.eval(
+                    exp, local_dict=cut_dict[next(iter(cut_dict))]["parameters"]
+                )
+
+            suffix = param_config.get("suffix", None)
+            initial_param = "AoE_Uncorr" if suffix is None else f"AoE_Uncorr_{suffix}"
+            data[initial_param] = (
+                data[param_config["current_param"]] / data[param_config["energy_param"]]
+            )
+
+            start = time.time()
+            msg = f"calibrating A/E for {name}"
+            log.info(msg)
+
+            aoe = CalAoE(
+                cal_dicts=cal_dicts,
+                cal_energy_param=config["cal_energy_param"],
+                eres_func=eres_func,
+                pdf=eval(param_config.get("pdf", "aoe_peak")),
+                mean_func=eval(param_config.get("mean_func", "Pol1")),
+                sigma_func=eval(param_config.get("sigma_func", "SigmaFit")),
+                selection_string=f"{config['cut_field']}&(~is_pulser)",
+                dt_corr=param_config.get("dt_corr", False),
+                dep_correct=param_config.get("dep_correct", False),
+                dt_cut=param_config.get("dt_cut", None),
+                dt_param=param_config.get("dt_param", 3),
+                high_cut_val=param_config.get("high_cut_val", 3),
+                compt_bands_width=config.get("debug_mode", 20),
+                debug_mode=debug_mode | config.get("debug_mode", False),
+                **({"use_log_pdf": True} if use_log_pdf else {}),
+            )
+            aoe.update_cal_dicts(
+                {
+                    initial_param: {
+                        "expression": f"{param_config['current_param']}/{param_config['energy_param']}",
+                        "parameters": {},
+                    }
                 }
-            }
-        )
-        aoe.calibrate(data, "AoE_Uncorr", override_dict=override_dict)
+            )
+            aoe.calibrate(
+                data,
+                initial_param,
+                override_dict=override_dict,
+                **({} if suffix is None else {"suffix": suffix}),
+            )
 
-        msg = f"A/E calibration completed in {time.time() - start:.2f} seconds"
-        log.info(msg)
+            msg = f"A/E calibration for {name} completed in {time.time() - start:.2f} seconds"
+            log.info(msg)
 
-        out_dict = get_results_dict(aoe)
-        aoe_plot_dict = fill_plot_dict(aoe, data, config.get("plot_options", None))
+            out_dicts[name] = get_results_dict(aoe)
+            aoe_plots = fill_plot_dict(
+                aoe, data, param_config.get("plot_options", None)
+            )
 
-        aoe.pdf = aoe.pdf.name
-        # need to change eres func as can't pickle lambdas
-        try:
-            aoe.eres_func = results_dicts[next(iter(results_dicts))]["partition_ecal"][
-                config["cal_energy_param"]
-            ]["eres_linear"]
-        except KeyError:
-            aoe.eres_func = {}
+            aoe.pdf = aoe.pdf.name
+            # need to change eres func as can't pickle lambdas
+            try:
+                aoe.eres_func = results_dicts[next(iter(results_dicts))][
+                    "partition_ecal"
+                ][config["cal_energy_param"]]["eres_linear"]
+            except KeyError:
+                aoe.eres_func = {}
+            aoe_objs[name] = copy.deepcopy(aoe)
+            aoe_plot_dict[name] = copy.deepcopy(aoe_plots)
     else:
-        out_dict = dict.fromkeys(cal_dicts)
+        out_dicts = {}
+        aoe_objs = {}
         aoe_plot_dict = {}
-        aoe = None
 
     out_result_dicts = {}
     for tstamp, result_dict in results_dicts.items():
-        out_result_dicts[tstamp] = dict(**result_dict, aoe=out_dict[tstamp])
+        out_result_dicts[tstamp] = dict(
+            **result_dict, aoe={name: d[tstamp] for name, d in out_dicts.items()}
+        )
 
     out_object_dicts = {}
     for tstamp, object_dict in object_dicts.items():
-        out_object_dicts[tstamp] = dict(**object_dict, aoe=aoe)
+        out_object_dicts[tstamp] = dict(**object_dict, aoe=aoe_objs)
 
     common_dict = (
         aoe_plot_dict.pop("common") if "common" in list(aoe_plot_dict) else None
@@ -381,27 +422,27 @@ def par_geds_hit_aoe() -> None:
     if kwarg_dict["run_aoe"] is True:
         require_config_keys(
             kwarg_dict,
-            ["current_param", "energy_param", "cal_energy_param", "cut_field"],
+            ["cal_energy_param", "cut_field", "threshold", "params"],
             f"aoe config ({args.config_file})",
         )
         params = [
-            kwarg_dict["current_param"],
-            "tp_0_est",
-            "tp_99",
-            kwarg_dict["energy_param"],
             kwarg_dict["cal_energy_param"],
             kwarg_dict["cut_field"],
+            "tp_0_est",
+            "tp_99",
             "timestamp",
         ]
-
-        if "dt_param" in kwarg_dict:
-            params.append(kwarg_dict["dt_param"])
-        else:
-            params.append("dt_eff")
-
-        if "dt_cut" in kwarg_dict and kwarg_dict["dt_cut"] is not None:
-            cal_dict.update(kwarg_dict["dt_cut"]["cut"])
-            params.append(kwarg_dict["dt_cut"]["out_param"])
+        for param_config in kwarg_dict["params"].values():
+            params.append(param_config["current_param"])
+            params.append(param_config["energy_param"])
+            if "dt_param" in param_config:
+                params.append(param_config["dt_param"])
+            else:
+                params.append("dt_eff")
+            if "dt_cut" in param_config and param_config["dt_cut"] is not None:
+                cal_dict.update(param_config["dt_cut"]["cut"])
+                params.append(param_config["dt_cut"]["out_param"])
+        params = list(dict.fromkeys(params))
         # load data in
         data, threshold_mask = load_data(
             files,
@@ -449,10 +490,10 @@ def par_geds_hit_aoe() -> None:
         )
         cal_dict = cal_dict[args.timestamp]
         results_dict = results_dicts[args.timestamp]
-        aoe = object_dicts[args.timestamp]
+        aoe = object_dicts[args.timestamp]["aoe"]
         plot_dict = plot_dicts[args.timestamp]
     else:
-        aoe = None
+        aoe = {}
         plot_dict = out_plot_dict
         results_dict = {}
     if args.plot_file:

--- a/src/legenddataflowscripts/par/geds/hit/aoe.py
+++ b/src/legenddataflowscripts/par/geds/hit/aoe.py
@@ -8,7 +8,6 @@ import pickle as pkl
 import re
 import time
 import warnings
-from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
@@ -26,6 +25,7 @@ from ....utils import (
     get_pulser_mask,
     prepare_output_paths,
     require_config_keys,
+    require_unique_suffixes,
 )
 
 log = logging.getLogger(__name__)
@@ -148,6 +148,7 @@ def run_aoe_calibration(
             ["cal_energy_param", "cut_field", "params"],
             "aoe calibration config",
         )
+        require_unique_suffixes(config["params"], "aoe calibration config")
         aoe_objs = {}
         aoe_plot_dict = {}
         out_dicts = {}
@@ -237,7 +238,9 @@ def run_aoe_calibration(
                 dt_cut=param_config.get("dt_cut", None),
                 dt_param=param_config.get("dt_param", 3),
                 high_cut_val=param_config.get("high_cut_val", 3),
-                compt_bands_width=config.get("debug_mode", 20),
+                compt_bands_width=param_config.get(
+                    "compt_bands_width", config.get("compt_bands_width", 20)
+                ),
                 debug_mode=debug_mode | config.get("debug_mode", False),
                 **({"use_log_pdf": True} if use_log_pdf else {}),
             )

--- a/src/legenddataflowscripts/par/geds/hit/lq.py
+++ b/src/legenddataflowscripts/par/geds/hit/lq.py
@@ -453,7 +453,12 @@ def par_geds_hit_lq() -> None:
             kwarg_dict["cal_energy_param"],
             kwarg_dict["cut_field"],
         ]
-        for param_config in kwarg_dict["params"].values():
+        for name, param_config in kwarg_dict["params"].items():
+            require_config_keys(
+                param_config,
+                ["lq_param", "energy_param"],
+                f"lq config params entry '{name}' ({args.config_file})",
+            )
             params.append(param_config["lq_param"])
             params.append(param_config["energy_param"])
             params.append(param_config.get("dt_param", "dt_eff"))

--- a/src/legenddataflowscripts/par/geds/hit/lq.py
+++ b/src/legenddataflowscripts/par/geds/hit/lq.py
@@ -66,23 +66,25 @@ def lq_calibration(
     dt_param: str,
     eres_func: callable,
     cdf: callable = gaussian,
+    lq_param: str = "lq80",
     selection_string: str = "",
     plot_options: dict | None = None,
     debug_mode: bool = False,
     use_log_pdf: bool = False,
+    suffix: str | None = None,
 ):
     """Calibrate the LQ (late-charge) pulse-shape discriminant.
 
     Constructs a :class:`~pygama.pargen.lq_cal.LQCal` instance, computes the
-    energy-normalised LQ observable ``LQ_Ecorr = lq80 / energy_param``, and
+    energy-normalised LQ observable ``LQ_Ecorr = lq_param / energy_param``, and
     calls :meth:`~pygama.pargen.lq_cal.LQCal.calibrate`.  The resulting cut
     expressions are appended to *cal_dicts*.
 
     Parameters
     ----------
     data : pandas.DataFrame
-        Event-level data containing ``lq80``, *energy_param*, *cal_energy_param*,
-        *dt_param*, and any selection columns.
+        Event-level data containing *lq_param*, *energy_param*,
+        *cal_energy_param*, *dt_param*, and any selection columns.
     cal_dicts : dict
         Mapping of run timestamps → hit-level calibration operations.
         Updated in-place with the LQ cut expression.
@@ -97,6 +99,8 @@ def lq_calibration(
     cdf : callable
         Cumulative distribution function used for binned LQ fitting.
         Defaults to :func:`pygama.math.distributions.gaussian`.
+    lq_param : str
+        Raw LQ parameter name to calibrate.  Defaults to ``"lq80"``.
     selection_string : str
         Pandas query string applied before calibration.  Defaults to ``""``.
     plot_options : dict, optional
@@ -109,6 +113,12 @@ def lq_calibration(
         log-densities (iminuit ``log=True`` mode) — faster, results differ
         at machine-precision level.  Silently ignored when the installed
         pygama does not support it.
+    suffix : str, optional
+        Appended (underscore-separated) to all output parameter names, e.g.
+        ``suffix="foo"`` produces ``LQ_Ecorr_foo`` … ``LQ_Cut_foo``.  Lets
+        several LQ parameters be calibrated side by side without their
+        hit-level operations colliding.  Requires a pygama version whose
+        :meth:`~pygama.pargen.lq_cal.LQCal.calibrate` supports ``suffix``.
 
     Returns
     -------
@@ -137,18 +147,19 @@ def lq_calibration(
         **({"use_log_pdf": True} if use_log_pdf else {}),
     )
 
-    data["LQ_Ecorr"] = np.divide(data["lq80"], data[energy_param])
+    initial_param = "LQ_Ecorr" if suffix is None else f"LQ_Ecorr_{suffix}"
+    data[initial_param] = np.divide(data[lq_param], data[energy_param])
 
     lq.update_cal_dicts(
         {
-            "LQ_Ecorr": {
-                "expression": f"lq80/{energy_param}",
+            initial_param: {
+                "expression": f"{lq_param}/{energy_param}",
                 "parameters": {},
             }
         }
     )
 
-    lq.calibrate(data, "LQ_Ecorr")
+    lq.calibrate(data, initial_param, **({} if suffix is None else {"suffix": suffix}))
     return cal_dicts, get_results_dict(lq), fill_plot_dict(lq, data, plot_options), lq
 
 
@@ -184,11 +195,16 @@ def run_lq_calibration(
         ``{timestamp: plot_dict}`` mapping of existing diagnostic figures.
     configs : dict or str or list
         LQ calibration configuration.  Must contain ``run_lq`` (bool),
-        ``energy_param``, ``cal_energy_param``, ``cut_field``, and
-        ``dt_param``.  Optional key ``use_log_pdf`` (bool, default false):
-        build the survival-fraction unbinned fits from the models'
-        log-densities (iminuit ``log=True``) — substantially faster, results
-        differ at machine-precision level; requires a pygama version with
+        ``cal_energy_param``, ``cut_field``, and ``params`` — a mapping of
+        ``{name: param_config}`` with one entry per LQ parameter to
+        calibrate.  Each *param_config* must contain ``lq_param`` and
+        ``energy_param``; optional keys are ``dt_param`` (default
+        ``"dt_eff"``), ``cdf``, ``suffix`` (appended to the output parameter
+        names so entries don't collide), and ``plot_options``.  Optional
+        top-level key ``use_log_pdf`` (bool, default false): build the
+        survival-fraction unbinned fits from the models' log-densities
+        (iminuit ``log=True``) — substantially faster, results differ at
+        machine-precision level; requires a pygama version with
         ``use_log_pdf`` support (silently ignored otherwise).
     debug_mode : bool
         Activates additional diagnostic output.  Defaults to ``False``.
@@ -198,27 +214,29 @@ def run_lq_calibration(
     cal_dicts : dict
         Updated calibration operations mappings.
     out_result_dicts : dict
-        Updated results mappings including LQ results.
+        Updated results mappings; LQ results are nested per ``params`` entry
+        under the ``lq`` key.
     out_object_dicts : dict
-        Updated object mappings including the ``LQCal`` instance.
+        Updated object mappings including one ``LQCal`` instance per
+        ``params`` entry.
     out_plot_dicts : dict
-        Updated plot mappings including LQ diagnostic figures.
+        Updated plot mappings including LQ diagnostic figures per ``params``
+        entry.
     """
     if isinstance(configs, str | list):
         configs = Props.read_from(configs)
 
     require_config_keys(configs, ["run_lq"], "lq calibration config")
 
-    if configs.pop("run_lq") is True:
+    if configs["run_lq"] is True:
         require_config_keys(
             configs,
-            ["energy_param", "cal_energy_param", "dt_param", "cut_field"],
+            ["cal_energy_param", "cut_field", "params"],
             "lq calibration config",
         )
-        if "plot_options" in configs:
-            for field, item in configs["plot_options"].items():
-                configs["plot_options"][field]["function"] = eval(item["function"])
-
+        lq_objs = {}
+        lq_plot_dict = {}
+        out_dicts = {}
         try:
             eres = copy.deepcopy(
                 results_dicts[next(iter(results_dicts))]["partition_ecal"][
@@ -247,46 +265,60 @@ def run_lq_calibration(
                 def eres_func(x):
                     return x * np.nan
 
-        log.info("starting lq calibration")
-        start = time.time()
-        cal_dicts, out_dict, lq_plot_dict, lq_obj = lq_calibration(
-            data,
-            cal_dicts=cal_dicts,
-            energy_param=configs["energy_param"],
-            cal_energy_param=configs["cal_energy_param"],
-            dt_param=configs["dt_param"],
-            eres_func=eres_func,
-            cdf=eval(configs.get("cdf", "gaussian")),
-            selection_string=f"{configs.pop('cut_field')}&(~is_pulser)",
-            plot_options=configs.get("plot_options", None),
-            debug_mode=debug_mode | configs.get("debug_mode", False),
-            use_log_pdf=configs.get("use_log_pdf", False),
-        )
-        msg = f"lq calibration took {time.time() - start:.2f} seconds"
-        log.info(msg)
-        # need to change eres func as can't pickle lambdas
-        try:
-            lq_obj.eres_func = results_dicts[next(iter(results_dicts))][
-                "partition_ecal"
-            ][configs["cal_energy_param"]]["eres_linear"]
-        except KeyError:
-            lq_obj.eres_func = {}
-    else:
-        out_dict = dict.fromkeys(cal_dicts)
-        lq_plot_dict = {}
-        lq_obj = None
+        for name, param_config in configs["params"].items():
+            require_config_keys(
+                param_config,
+                ["lq_param", "energy_param"],
+                f"lq calibration config params entry '{name}'",
+            )
+            if "plot_options" in param_config:
+                for field, item in param_config["plot_options"].items():
+                    param_config["plot_options"][field]["function"] = eval(
+                        item["function"]
+                    )
 
-    # mirror the aoe result shape: one (shared) lq results entry per timestamp
-    if not isinstance(out_dict, dict) or set(out_dict) != set(cal_dicts):
-        out_dict = dict.fromkeys(cal_dicts, out_dict)
+            msg = f"starting lq calibration for {name}"
+            log.info(msg)
+            start = time.time()
+            cal_dicts, out_dict, lq_plots, lq_obj = lq_calibration(
+                data,
+                cal_dicts=cal_dicts,
+                energy_param=param_config["energy_param"],
+                cal_energy_param=configs["cal_energy_param"],
+                dt_param=param_config.get("dt_param", "dt_eff"),
+                eres_func=eres_func,
+                cdf=eval(param_config.get("cdf", "gaussian")),
+                lq_param=param_config["lq_param"],
+                selection_string=f"{configs['cut_field']}&(~is_pulser)",
+                plot_options=param_config.get("plot_options", None),
+                debug_mode=debug_mode | configs.get("debug_mode", False),
+                use_log_pdf=configs.get("use_log_pdf", False),
+                suffix=param_config.get("suffix", None),
+            )
+            msg = f"lq calibration for {name} took {time.time() - start:.2f} seconds"
+            log.info(msg)
+            # need to change eres func as can't pickle lambdas
+            try:
+                lq_obj.eres_func = results_dicts[next(iter(results_dicts))][
+                    "partition_ecal"
+                ][configs["cal_energy_param"]]["eres_linear"]
+            except KeyError:
+                lq_obj.eres_func = {}
+            out_dicts[name] = out_dict
+            lq_objs[name] = copy.deepcopy(lq_obj)
+            lq_plot_dict[name] = copy.deepcopy(lq_plots)
+    else:
+        out_dicts = {}
+        lq_objs = {}
+        lq_plot_dict = {}
 
     out_result_dicts = {}
     for tstamp, result_dict in results_dicts.items():
-        out_result_dicts[tstamp] = dict(**result_dict, lq=out_dict[tstamp])
+        out_result_dicts[tstamp] = dict(**result_dict, lq=dict(out_dicts))
 
     out_object_dicts = {}
     for tstamp, object_dict in object_dicts.items():
-        out_object_dicts[tstamp] = dict(**object_dict, lq=lq_obj)
+        out_object_dicts[tstamp] = dict(**object_dict, lq=lq_objs)
 
     common_dict = lq_plot_dict.pop("common") if "common" in list(lq_plot_dict) else None
     out_plot_dicts = {}
@@ -335,8 +367,9 @@ def par_geds_hit_lq() -> None:
         Logging configuration file.
     ``--config-file`` : list of str
         LQ calibration configuration file(s).  Must contain ``run_lq``
-        (bool), ``energy_param``, ``cal_energy_param``, ``cut_field``,
-        ``dt_param``, and ``threshold``.
+        (bool), ``cal_energy_param``, ``cut_field``, ``threshold``, and
+        ``params`` — one entry per LQ parameter to calibrate (see
+        :func:`run_lq_calibration`).
     ``--table-name`` : str
         LH5 table path within the DSP files.
     ``--timestamp`` : str
@@ -411,18 +444,20 @@ def par_geds_hit_lq() -> None:
     if kwarg_dict["run_lq"] is True:
         require_config_keys(
             kwarg_dict,
-            ["energy_param", "cal_energy_param", "cut_field", "threshold"],
+            ["cal_energy_param", "cut_field", "threshold", "params"],
             f"lq config ({args.config_file})",
         )
         files = expand_filelist(args.files)
 
         params = [
-            "lq80",
-            "dt_eff",
-            kwarg_dict["energy_param"],
             kwarg_dict["cal_energy_param"],
             kwarg_dict["cut_field"],
         ]
+        for param_config in kwarg_dict["params"].values():
+            params.append(param_config["lq_param"])
+            params.append(param_config["energy_param"])
+            params.append(param_config.get("dt_param", "dt_eff"))
+        params = list(dict.fromkeys(params))
 
         # load data in
         data, threshold_mask = load_data(
@@ -430,7 +465,7 @@ def par_geds_hit_lq() -> None:
             args.table_name,
             cal_dict,
             params=params,
-            threshold=kwarg_dict.pop("threshold"),
+            threshold=kwarg_dict["threshold"],
             return_selection_mask=True,
         )
 
@@ -464,10 +499,10 @@ def par_geds_hit_lq() -> None:
         cal_dict = out_dicts[args.timestamp]
         results_dict = results_dicts[args.timestamp]
         plot_dict = plot_dicts[args.timestamp]
-        lq = lq_dict[args.timestamp]
+        lq = lq_dict[args.timestamp]["lq"]
 
     else:
-        lq = None
+        lq = {}
         results_dict = {}
 
     if args.plot_file:

--- a/src/legenddataflowscripts/par/geds/hit/lq.py
+++ b/src/legenddataflowscripts/par/geds/hit/lq.py
@@ -27,6 +27,7 @@ from ....utils import (
     get_pulser_mask,
     prepare_output_paths,
     require_config_keys,
+    require_unique_suffixes,
 )
 
 log = logging.getLogger(__name__)
@@ -234,6 +235,7 @@ def run_lq_calibration(
             ["cal_energy_param", "cut_field", "params"],
             "lq calibration config",
         )
+        require_unique_suffixes(configs["params"], "lq calibration config")
         lq_objs = {}
         lq_plot_dict = {}
         out_dicts = {}

--- a/src/legenddataflowscripts/utils/__init__.py
+++ b/src/legenddataflowscripts/utils/__init__.py
@@ -6,6 +6,7 @@ from .cfgtools import (
     get_rule_config,
     require_config_keys,
     require_peaks_present,
+    require_unique_suffixes,
 )
 from .convert_np import convert_dict_np_to_float
 from .discharge import get_is_recovering_mask
@@ -36,5 +37,6 @@ __all__ = [
     "prepare_output_paths",
     "require_config_keys",
     "require_peaks_present",
+    "require_unique_suffixes",
     "take_table_rows",
 ]

--- a/src/legenddataflowscripts/utils/cfgtools.py
+++ b/src/legenddataflowscripts/utils/cfgtools.py
@@ -102,6 +102,32 @@ def require_peaks_present(
         raise ValueError(msg)
 
 
+def require_unique_suffixes(params: Mapping, context: str) -> None:
+    """Raise ValueError when ``params`` entries share an output suffix.
+
+    Multi-parameter calibration configs derive their output column and
+    cal-dict names from each entry's optional ``suffix``; two entries with
+    the same suffix (including two entries with no suffix at all) would
+    silently overwrite each other's results.
+
+    Parameters
+    ----------
+    params : collections.abc.Mapping
+        The ``params`` mapping of a multi-parameter calibration config.
+    context : str
+        Free-form string naming the config in the error message.
+    """
+    suffixes = [entry.get("suffix") for entry in params.values()]
+    duplicated = {s for s in suffixes if suffixes.count(s) > 1}
+    if duplicated:
+        labels = sorted("<no suffix>" if s is None else repr(s) for s in duplicated)
+        msg = (
+            f"{context}: params entries share the same suffix value(s) "
+            f"({', '.join(labels)}); their outputs would overwrite each other"
+        )
+        raise ValueError(msg)
+
+
 def get_rule_config(configs_path, rule_name, timestamp, datatype):
     """Resolve the dataflow config for one Snakemake rule.
 

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -22,6 +22,7 @@ from legenddataflowscripts.utils import (
     parse_json_arg,
     prepare_output_paths,
     require_config_keys,
+    require_unique_suffixes,
 )
 
 
@@ -211,3 +212,22 @@ def test_build_log_excepthook(tmp_path, monkeypatch):
     assert log_file.read_text().count("uncaught exception") == 1
 
     assert isinstance(log, logging.Logger)
+
+
+def test_require_unique_suffixes():
+    # distinct suffixes, and a single unsuffixed entry, are fine
+    require_unique_suffixes(
+        {"a": {"suffix": "low"}, "b": {"suffix": "high"}, "c": {}}, "test config"
+    )
+
+    # two entries with the same explicit suffix would overwrite each other
+    with pytest.raises(ValueError, match=r"test config: params entries share"):
+        require_unique_suffixes(
+            {"a": {"suffix": "low"}, "b": {"suffix": "low"}}, "test config"
+        )
+
+    # ... as would two entries that both omit the suffix
+    with pytest.raises(ValueError, match="<no suffix>"):
+        require_unique_suffixes(
+            {"a": {}, "b": {"current_param": "A_max"}}, "test config"
+        )


### PR DESCRIPTION
## Summary

Extends the LQ calibration to handle multiple LQ parameters, mirroring the multi-parameter A/E schema from #42: `run_lq_calibration` loops over `config["params"]` — one entry per LQ parameter, each with its own `lq_param` (no longer hardcoded `lq80`), `energy_param`, and optional `dt_param`/`cdf`/`suffix`/`plot_options`. Results nest per entry under the `lq` key, pickled objects as `{name: LQCal}`, plots per name. Config shape:

```yaml
run_lq: true
threshold: 800
cal_energy_param: cuspEmax_ctc_cal
cut_field: is_valid_cal
params:
  lq:
    lq_param: lq80
    energy_param: cuspEmax
  lq_alt:
    lq_param: lq80
    energy_param: cuspEmax
    suffix: alt
```

Suffixed entries require `LQCal.calibrate` suffix support (legend-exp/pygama#707); the kwarg is only passed when a suffix is configured, so unsuffixed entries keep working with released pygama. The `par-geds-hit-lq` entry point builds its column list from all entries and now stores just the `{name: LQCal}` mapping under the pickle's `lq` key instead of re-nesting the full object dict.

The second commit pre-resolves the `aoe.py` divergence with main: it brings the params-loop `run_aoe_calibration` from #42 into this lineage combined with the `use_log_pdf` knob, and carries the schema fixes from #46.

**Stacked on #44** (`perf-par-dsp`) — only the two commits on top are new.

## Test plan

Full suite (unit + skimmed-data integration hit chain, ecal→aoe→qc→lq): 71 passed locally, with the LQ config exercising an unsuffixed primary plus a suffixed duplicate entry end to end, and the aoe config migrated to the params schema. Companion legend-dataflow pht chain (partcal→aoe→lq→fast) also passes.

Per `AI_POLICY.md`: developed with AI assistance (Claude); reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)